### PR TITLE
简化GitHub工作流触发规则

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -7,9 +7,6 @@ on:
       - 'release-*'
     branches:
       - main
-  pull_request:
-    branches:
-      - 'main'
   pull_request_target:
     branches:
       - '*'


### PR DESCRIPTION
删除了不再使用的'release-*'分支触发规则，移除了不必要的pull_request分支指定，使工作流能够在所有分支上触发。