### PR TITLE
 CI : Add auto-upload for releases and refine PR labeling

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1,20 +1,16 @@
 name: CI/CD Workflow
 
 on:
-  push:
-    tags:
-      - 'v*'
-      - 'release-*'
-    branches:
-      - main
   pull_request_target:
     branches:
       - '*'
     types: [labeled]
+  release:
+    types: [published]
       
 jobs:        
   check:
-    if: github.event.label.name == 'reviewed'
+    if: github.event.label.name == 'ci ready' || github.event_name == 'release'
     uses: ./.github/workflows/cppcheck.yml
     with:
       image_name: registry.agibot.com/agibot-tech/gitlab-ci
@@ -22,7 +18,6 @@ jobs:
     secrets: inherit
   
   test_gcc11_amd64:
-    if: github.event.label.name == 'reviewed'
     uses: ./.github/workflows/test-workflow.yml
     with:
       image_name: registry.agibot.com/agibot-tech/aimrt_ci-amd64-gcc11-ubuntu22_04
@@ -33,7 +28,6 @@ jobs:
     needs: [check]
   
   test_gcc11_arm64:
-    if: github.event.label.name == 'reviewed'
     uses: ./.github/workflows/test-workflow.yml
     with:
       image_name: registry.agibot.com/agibot-tech/aimrt_ci-arm64-gcc11-ubuntu22_04


### PR DESCRIPTION
This update improves our CI/CD process with two key changes:

1. Automated wheel package upload for releases:
   - Implement automatic uploading of .whl packages when a new release is created.
   - This streamlines our release process and ensures consistent package distribution.

2. Rename PR label from "reviewed" to "ci ready":
   - Change the label that triggers CI checks from "reviewed" to "ci ready".
   - This new label name more clearly communicates its purpose in the CI workflow.
   - Update all related documentation and workflow files to reflect this change.
