### PR TITLE
build: reorganize CMake configuration to fix windows build by fetchcontent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,16 +88,16 @@ if(AIMRT_MASTER_PROJECT)
     endif()
   endif()
 
-  if(MSVC)
-    add_compile_options(/utf-8 /wd4819)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
-  endif()
-
-  if(WIN32)
-    add_compile_definitions(NOMINMAX)
-  endif()
-
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
+if(MSVC)
+  add_compile_options(/utf-8 /wd4819)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+endif()
+
+if(WIN32)
+  add_compile_definitions(NOMINMAX)
 endif()
 
 # Build document


### PR DESCRIPTION
Streamline CMake configuration by consolidating compiler options and ensuring consistent export of compile commands, enhancing the build process especially for MSVC and Windows environments.

Fix https://github.com/AimRT/AimRT/issues/17 problem 1