### PR TITLE
build: add Windows specific compile option for ssize_t

### DIFF
--- a/src/plugins/grpc_plugin/CMakeLists.txt
+++ b/src/plugins/grpc_plugin/CMakeLists.txt
@@ -37,6 +37,11 @@ target_link_libraries(
           aimrt::common::net
           nghttp2::nghttp2)
 
+# Set compile options of target
+if(WIN32)
+  target_compile_definitions(${CUR_TARGET_NAME} PRIVATE ssize_t=long)
+endif()
+
 # Add -Werror option
 include(AddWerror)
 add_werror(${CUR_TARGET_NAME})

--- a/src/plugins/grpc_plugin/grpc/message.h
+++ b/src/plugins/grpc_plugin/grpc/message.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 
 namespace aimrt::plugins::grpc_plugin::grpc {


### PR DESCRIPTION
Ensure compatibility on Windows by defining ssize_t as int for the gRPC plugin. This adjustment prevents potential type-related issues during compilation.

Fix https://github.com/AimRT/AimRT/issues/17 problem 2.