### PR TITLE
build: simplify Boost fetching logic

### DIFF
--- a/cmake/GetBoost.cmake
+++ b/cmake/GetBoost.cmake
@@ -3,46 +3,32 @@
 
 include(FetchContent)
 
-message(STATUS "Searching for Boost...")
+message(STATUS "get boost...")
 
-set(BOOST_VERSION 1.82.0)
 set(boost_DOWNLOAD_URL
-    "https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.xz"
+    "https://github.com/boostorg/boost/releases/download/boost-1.82.0/boost-1.82.0.tar.xz"
     CACHE STRING "")
 
-find_package(Boost ${BOOST_VERSION} QUIET)
-
-if(Boost_FOUND)
-  if(Boost_VERSION VERSION_EQUAL ${BOOST_VERSION})
-    message(STATUS "Found compatible Boost version ${Boost_VERSION}")
-  else()
-    message(WARNING "Found newer Boost version ${Boost_VERSION}. Using local version, but this may cause issues.")
-  endif()
+if(boost_LOCAL_SOURCE)
+  FetchContent_Declare(
+    boost
+    SOURCE_DIR ${boost_LOCAL_SOURCE}
+    OVERRIDE_FIND_PACKAGE)
 else()
-  message(STATUS "Boost ${BOOST_VERSION} or greater not found locally. Downloading Boost ${BOOST_VERSION}")
+  FetchContent_Declare(
+    boost
+    URL ${boost_DOWNLOAD_URL}
+    DOWNLOAD_EXTRACT_TIMESTAMP ON
+    OVERRIDE_FIND_PACKAGE)
+endif()
 
-  if(boost_LOCAL_SOURCE)
-    FetchContent_Declare(
-      boost
-      SOURCE_DIR ${boost_LOCAL_SOURCE}
-      OVERRIDE_FIND_PACKAGE)
-    message(STATUS "Using local Boost source")
-  else()
-    FetchContent_Declare(
-      boost
-      URL ${boost_DOWNLOAD_URL}
-      DOWNLOAD_EXTRACT_TIMESTAMP ON
-      OVERRIDE_FIND_PACKAGE)
-  endif()
+FetchContent_GetProperties(boost)
+if(NOT boost_POPULATED)
+  set(BOOST_INCLUDE_LIBRARIES asio beast)
 
-  FetchContent_GetProperties(boost)
-  if(NOT boost_POPULATED)
-    set(BOOST_INCLUDE_LIBRARIES asio beast)
+  set(Boost_USE_STATIC_LIBS
+      ON
+      CACHE BOOL "")
 
-    set(Boost_USE_STATIC_LIBS
-        ON
-        CACHE BOOL "")
-
-    FetchContent_MakeAvailable(boost)
-  endif()
+  FetchContent_MakeAvailable(boost)
 endif()


### PR DESCRIPTION
Streamline the process of finding and downloading Boost by removing unnecessary checks and consolidating the logic, making it easier to manage and maintain dependencies.