### PR TITLE
fix: aimrt_py channel benchmark for large data packets

### DIFF
--- a/src/examples/py/pb_chn_bench/benchmark_publisher_module.py
+++ b/src/examples/py/pb_chn_bench/benchmark_publisher_module.py
@@ -209,8 +209,7 @@ class BenchmarkPublisher(aimrt_py.ModuleBase):
 
         while send_count < plan['msg_count'] and self.run_flag:
             msg.seq = send_count
-            msg.timestamp = int(time.time() * 1e9)  # ns
-
+            msg.timestamp = time.perf_counter_ns()
             aimrt_py.Publish(publisher, msg)
 
             send_count += 1

--- a/src/examples/py/pb_chn_bench/benchmark_publisher_module.py
+++ b/src/examples/py/pb_chn_bench/benchmark_publisher_module.py
@@ -189,6 +189,9 @@ class BenchmarkPublisher(aimrt_py.ModuleBase):
 
         self.publish_complete_event.wait()
 
+        # wait for subscriber to receive all messages
+        time.sleep(1)
+
         # publish end signal
         end_signal = benchmark_pb2.BenchmarkSignal()
         end_signal.status = benchmark_pb2.BenchmarkStatus.End

--- a/src/examples/py/pb_chn_bench/benchmark_subscriber_module.py
+++ b/src/examples/py/pb_chn_bench/benchmark_subscriber_module.py
@@ -124,7 +124,7 @@ class BenchmarkSubscriber(aimrt_py.ModuleBase):
                 aimrt_py.error(self.logger, f"Unknown signal status: {signal_msg.status}")
 
     def MessageCallback(self, topic_index: int, benchmark_msg: benchmark_pb2.BenchmarkMessage) -> None:
-        recv_timestamp = time.time() * 1e9  # ns
+        recv_timestamp = time.perf_counter_ns()
 
         topic_name = f"test_topic_{topic_index}"
         self.topic_record_map[topic_name].msg_record_vec[benchmark_msg.seq].recv = True

--- a/src/examples/py/pb_rpc_bench/benchmark_rpc_client_module.py
+++ b/src/examples/py/pb_rpc_bench/benchmark_rpc_client_module.py
@@ -150,7 +150,7 @@ class BenchmarkRpcClientModule(aimrt_py.ModuleBase):
         self.completed_tasks = 0
         self.total_tasks = plan['parallel']
 
-        start_time = time.time()
+        start_time = time.perf_counter_ns()
 
         # start rpc tasks
         self.perf_data = []
@@ -161,8 +161,8 @@ class BenchmarkRpcClientModule(aimrt_py.ModuleBase):
         # wait for all tasks to complete
         self.request_complete_event.wait()
 
-        end_time = time.time()
-        total_time_ms = (end_time - start_time) * 1e3
+        end_time = time.perf_counter_ns()
+        total_time_ms = (end_time - start_time) / 1e6
 
         self.perf_data.sort()
 


### PR DESCRIPTION
- ensure subscriber receives all messages before ending
- optimize timestamp retrieval for benchmarking