### PR TITLE
fix: standardize timestamp handling with time.time_ns()

### DIFF
--- a/src/examples/py/pb_chn_bench/benchmark_publisher_module.py
+++ b/src/examples/py/pb_chn_bench/benchmark_publisher_module.py
@@ -1,9 +1,7 @@
 # Copyright (c) 2024 The AimRT Authors.
 # AimRT is licensed under Mulan PSL v2.
 
-import os
 import random
-import signal
 import string
 import threading
 import time
@@ -209,7 +207,7 @@ class BenchmarkPublisher(aimrt_py.ModuleBase):
 
         while send_count < plan['msg_count'] and self.run_flag:
             msg.seq = send_count
-            msg.timestamp = time.perf_counter_ns()
+            msg.timestamp = time.time_ns()
             aimrt_py.Publish(publisher, msg)
 
             send_count += 1

--- a/src/examples/py/pb_chn_bench/benchmark_subscriber_module.py
+++ b/src/examples/py/pb_chn_bench/benchmark_subscriber_module.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 The AimRT Authors.
 # AimRT is licensed under Mulan PSL v2.
 
-import os
-import signal
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List
@@ -16,8 +14,8 @@ from google.protobuf.json_format import MessageToJson
 @dataclass
 class MsgRecord:
     recv: bool = False
-    send_timestamp: float = 0
-    recv_timestamp: float = 0
+    send_timestamp: int = 0
+    recv_timestamp: int = 0
 
 
 @dataclass
@@ -124,7 +122,7 @@ class BenchmarkSubscriber(aimrt_py.ModuleBase):
                 aimrt_py.error(self.logger, f"Unknown signal status: {signal_msg.status}")
 
     def MessageCallback(self, topic_index: int, benchmark_msg: benchmark_pb2.BenchmarkMessage) -> None:
-        recv_timestamp = time.perf_counter_ns()
+        recv_timestamp = time.time_ns()
 
         topic_name = f"test_topic_{topic_index}"
         self.topic_record_map[topic_name].msg_record_vec[benchmark_msg.seq].recv = True

--- a/src/examples/py/pb_rpc_bench/benchmark_rpc_client_module.py
+++ b/src/examples/py/pb_rpc_bench/benchmark_rpc_client_module.py
@@ -203,13 +203,13 @@ class BenchmarkRpcClientModule(aimrt_py.ModuleBase):
 
         for _ in range(plan['msg_count']):
             ctx = aimrt_py.RpcContext()
-            task_start_time = time.time()
+            task_start_time = time.perf_counter_ns()
             status, _ = self.proxy.GetFooData(ctx, req)
-            task_end_time = time.time()
+            task_end_time = time.perf_counter_ns()
 
             assert status.Code() == aimrt_py.RpcStatusRetCode.OK, f"GetFooData failed: {status}"
             assert task_end_time > task_start_time, "Task end time is less than start time"
-            self.perf_data.append((task_end_time - task_start_time) * 1e6)  # us
+            self.perf_data.append((task_end_time - task_start_time) / 1e3)  # us
 
             if plan['perf_mode'] == 'fixed-freq':
                 time.sleep(1 / plan['freq'])


### PR DESCRIPTION
Update timestamp handling in both publishing and subscribing modules to use time.time_ns() instead of time.perf_counter_ns(). This change improves consistency in timestamp precision and ensures uniformity across the system's message timing functionalities.