### PR TITLE
docs: add aimrt_py channel context 

### DIFF
--- a/document/sphinx-cn/tutorials/interface_py/channel.md
+++ b/document/sphinx-cn/tutorials/interface_py/channel.md
@@ -104,7 +104,7 @@ protoc --python_out=. example.proto
 - `Reset()->void` ： 重置上下文，重置后上下文可以被再次使用；
 - `CheckUsed()->bool` ： 检查上下文是否被使用；
 - `SetUsed()->void` ： 设置上下文为已使用；
-- `GetType()->aimrt_channel_context_type_t` ： 获取上下文类型，返回值为`aimrt_channel_context_type_t`枚举类型，具体值为`AIMRT_CHANNEL_PUBLISHER_CONTEXT`或`AIMRT_CHANNEL_SUBSCRIBER_CONTEXT`；
+- `GetType()->aimrt_channel_context_type_t` ： 获取上下文类型；
 - `SetMetaValue(key: str, value: str)->void` ： 设置元数据；
 - `GetMetaValue(key: str)->str` ： 获取元数据；
 - `GetMetaKeys()->List[str]` ： 获取所有元数据键值对中的键列表；
@@ -113,6 +113,8 @@ protoc --python_out=. example.proto
 - `ToString()->str` ： 获取上下文信息，以字符串形式返回可读性高的信息；
 
 `ContextRef`是`Context`的引用类型，除不具备`Reset`接口外，其他接口与`Context`完全相同。
+
+`aimrt_channel_context_type_t` 是一个枚举类型，定义了上下文类型，具体值为`AIMRT_CHANNEL_PUBLISHER_CONTEXT`或`AIMRT_CHANNEL_SUBSCRIBER_CONTEXT`。
 
 
 ## 使用示例

--- a/src/examples/py/pb_chn/examples_py_pb_chn_publisher_app.py
+++ b/src/examples/py/pb_chn/examples_py_pb_chn_publisher_app.py
@@ -49,13 +49,38 @@ def main():
 
     # Publish event
     event_msg = event_pb2.ExampleEventMsg()
-    event_msg.msg = "example msg"
-    event_msg.num = 123456
-
-    aimrt_py.info(module_handle.GetLogger(),
-                  "Publish new pb event, data: {}".format(MessageToJson(event_msg)))
-
+    event_msg.msg = "Publish without ctx or serialization_type"
+    event_msg.num = 1
     aimrt_py.Publish(publisher, event_msg)
+    aimrt_py.info(module_handle.GetLogger(),
+                  f"Publish new pb event, data: {MessageToJson(event_msg)}")
+
+    # Publish event with json serialization
+    event_msg.msg = "Publish with json serialization"
+    event_msg.num = 2
+    aimrt_py.Publish(publisher, "json", event_msg)
+    aimrt_py.info(module_handle.GetLogger(),
+                  f"Publish new pb event, data: {MessageToJson(event_msg)}")
+
+    # Publish event with context
+    ctx = aimrt_py.Context()
+    ctx.SetMetaValue("key1", "value1")
+    event_msg.msg = "Publish with context"
+    event_msg.num = 3
+    aimrt_py.Publish(publisher, ctx, event_msg)
+    aimrt_py.info(module_handle.GetLogger(),
+                  f"Publish new pb event, data: {MessageToJson(event_msg)}")
+
+    # Publish event with context ref
+    ctx.Reset()  # Reset context, then it can be used again
+    ctx_ref = aimrt_py.ContextRef(ctx)
+    ctx_ref.SetMetaValue("key2", "value2")
+    ctx_ref.SetSerializationType("json")
+    event_msg.msg = "Publish with context ref"
+    event_msg.num = 4
+    aimrt_py.Publish(publisher, ctx_ref, event_msg)
+    aimrt_py.info(module_handle.GetLogger(),
+                  f"Publish new pb event, data: {MessageToJson(event_msg)}")
 
     # Sleep for seconds
     time.sleep(1)

--- a/src/examples/py/pb_chn/examples_py_pb_chn_subscriber_app.py
+++ b/src/examples/py/pb_chn/examples_py_pb_chn_subscriber_app.py
@@ -55,10 +55,11 @@ def main():
 
     # Subscribe
     subscriber = module_handle.GetChannelHandle().GetSubscriber(topic_name)
-    assert subscriber, "Get subscriber for topic '{}' failed.".format(topic_name)
+    assert subscriber, f"Get subscriber for topic '{topic_name}' failed."
 
-    def EventHandle(msg):
-        aimrt_py.info(module_handle.GetLogger(), "Get new pb event, data: {}".format(MessageToJson(msg)))
+    def EventHandle(ctx_ref, msg):
+        aimrt_py.info(module_handle.GetLogger(),
+                      f"Get new pb event, ctx: {ctx_ref.ToString()}, data: {MessageToJson(msg)}")
 
     aimrt_py.Subscribe(subscriber, event_pb2.ExampleEventMsg, EventHandle)
 

--- a/src/runtime/python_runtime/aimrt_py_pb_chn.py
+++ b/src/runtime/python_runtime/aimrt_py_pb_chn.py
@@ -84,6 +84,8 @@ def Publish(publisher: aimrt_python_runtime.PublisherRef, second, third=None):
             ctx_ref = aimrt_python_runtime.ContextRef(ctx)
         else:
             ctx_ref = ctx
+        if ctx_ref.GetSerializationType() == "":
+            ctx_ref.SetSerializationType("pb")
         serialized_msg = _SerializeProtobufMessage(pb_msg, ctx_ref.GetSerializationType())
         publisher.PublishWithCtx(f"pb:{pb_msg.DESCRIPTOR.full_name}", ctx_ref, serialized_msg)
     elif isinstance(ctx, str):

--- a/src/runtime/python_runtime/export_channel.h
+++ b/src/runtime/python_runtime/export_channel.h
@@ -17,6 +17,10 @@ inline void ExportContext(const pybind11::object& m) {
   using aimrt::channel::Context;
   using aimrt::channel::ContextRef;
 
+  pybind11::enum_<aimrt_channel_context_type_t>(m, "aimrt_channel_context_type_t")
+      .value("AIMRT_CHANNEL_PUBLISHER_CONTEXT", aimrt_channel_context_type_t::AIMRT_CHANNEL_PUBLISHER_CONTEXT)
+      .value("AIMRT_CHANNEL_SUBSCRIBER_CONTEXT", aimrt_channel_context_type_t::AIMRT_CHANNEL_SUBSCRIBER_CONTEXT);
+
   pybind11::class_<Context>(m, "Context")
       .def(pybind11::init<>())
       .def("CheckUsed", &Context::CheckUsed)


### PR DESCRIPTION
* Add documentation related to the aimrt_py channel context.
* Add aimrt_py channel context usage examples.
* Fix issue where the return value of the GetType method was not exported.
* Fixed an error when context serialization type was not set.