### PR TITLE
fix: code gen error for proto files without package declaration

### DIFF
--- a/src/tools/protoc_plugin_py_gen_aimrt_py_rpc/protoc_plugin_py_gen_aimrt_py_rpc.py
+++ b/src/tools/protoc_plugin_py_gen_aimrt_py_rpc/protoc_plugin_py_gen_aimrt_py_rpc.py
@@ -278,8 +278,8 @@ class {{service_name}}Proxy(aimrt_py.ProxyBase):
             py_package_name: str = file_name.replace('.proto', '_pb2').replace("/", ".")
 
             for message_type in proto_file.message_type:
-                message_type_full_name = "." + package_name + "." + message_type.name
-                message_type_py_name = py_package_name + "." + message_type.name
+                message_type_full_name = "." + ".".join(filter(None, [package_name, message_type.name]))
+                message_type_py_name = ".".join(filter(None, [py_package_name, message_type.name]))
                 message_type_py_name_dict[message_type_full_name] = message_type_py_name
 
         # Generate code for each file


### PR DESCRIPTION
Enhance the generation of message type names by ensuring proper handling of package and message components, eliminating excess separators for cleaner output.