### PR TITLE
Fix/logger thread safety

### DIFF
--- a/src/runtime/core/logger/logger_manager.cc
+++ b/src/runtime/core/logger/logger_manager.cc
@@ -173,11 +173,12 @@ void LoggerManager::RegisterLoggerBackendGenFunc(
 }
 
 /**
- * @brief Get a LoggerProxy for a given module.
- * @param module_info Detailed information about the module.
+ * @brief Get a LoggerProxy by name in a thread-safe manner.
+ * @param logger_name Name of the logger.
  * @return Reference to the LoggerProxy instance.
  *
- * This function retrieves or creates a LoggerProxy for the specified module.
+ * This function retrieves or creates a LoggerProxy with the given name.
+ * It is thread-safe and can be called concurrently from multiple threads.
  */
 const LoggerProxy& LoggerManager::GetLoggerProxy(const util::ModuleDetailInfo& module_info) {
   AIMRT_CHECK_ERROR_THROW(
@@ -210,11 +211,12 @@ const LoggerProxy& LoggerManager::GetLoggerProxy(const util::ModuleDetailInfo& m
 
 
 /**
- * @brief Get a LoggerProxy by name.
+ * @brief Get a LoggerProxy by name in a thread-safe manner.
  * @param logger_name Name of the logger.
  * @return Reference to the LoggerProxy instance.
  *
  * This function retrieves or creates a LoggerProxy with the given name.
+ * It is thread-safe and can be called concurrently from multiple threads.
  */
 const LoggerProxy& LoggerManager::GetLoggerProxy(std::string_view logger_name) {
   AIMRT_CHECK_ERROR_THROW(
@@ -236,7 +238,13 @@ const LoggerProxy& LoggerManager::GetLoggerProxy(std::string_view logger_name) {
   return *(emplace_ret.first->second);
 }
 
-
+/**
+ * @brief Retrieve the log levels of all loggers in a thread-safe manner.
+ * @return A map of logger names and their corresponding log levels.
+ *
+ * This function returns the current log levels of all registered loggers.
+ * It is thread-safe and can be called concurrently from multiple threads.
+ */
 std::unordered_map<std::string, aimrt_log_level_t> LoggerManager::GetAllLoggerLevels() const {
   std::unordered_map<std::string, aimrt_log_level_t> result;
   std::lock_guard<std::mutex> lock(logger_proxy_map_mutex_);  // 添加锁保护
@@ -247,7 +255,13 @@ std::unordered_map<std::string, aimrt_log_level_t> LoggerManager::GetAllLoggerLe
   return result;
 }
 
-
+/**
+ * @brief Set the log levels for multiple loggers in a thread-safe manner.
+ * @param logger_lvls A map of logger names and their corresponding log levels.
+ *
+ * This function updates the log levels of the specified loggers.
+ * It is thread-safe and can be called concurrently from multiple threads.
+ */
 void LoggerManager::SetLoggerLevels(
     const std::unordered_map<std::string, aimrt_log_level_t>& logger_lvls) {
   std::lock_guard<std::mutex> lock(logger_proxy_map_mutex_);  // 添加锁保护

--- a/src/runtime/core/logger/logger_manager.cc
+++ b/src/runtime/core/logger/logger_manager.cc
@@ -58,6 +58,13 @@ struct convert<aimrt::runtime::core::logger::LoggerManager::Options> {
 
 namespace aimrt::runtime::core::logger {
 
+/**
+ * @brief Initialize the LoggerManager with the given options.
+ * @param options_node YAML node containing configuration options.
+ *
+ * This function sets up the logger backends based on the provided configuration.
+ * It should be called only once during the application's lifetime.
+ */
 void LoggerManager::Initialize(YAML::Node options_node) {
   RegisterConsoleLoggerBackendGenFunc();
   RegisterRotateFileLoggerBackendGenFunc();
@@ -103,6 +110,12 @@ void LoggerManager::Initialize(YAML::Node options_node) {
   AIMRT_INFO("Logger manager init complete");
 }
 
+/**
+ * @brief Start the LoggerManager.
+ *
+ * This function starts all registered logger backends.
+ * It should be called after Initialize().
+ */
 void LoggerManager::Start() {
   AIMRT_CHECK_ERROR_THROW(
       std::atomic_exchange(&state_, State::kStart) == State::kInit,
@@ -115,6 +128,12 @@ void LoggerManager::Start() {
   AIMRT_INFO("Logger manager start completed.");
 }
 
+/**
+ * @brief Shutdown the LoggerManager.
+ *
+ * This function gracefully shuts down all logger backends.
+ * It can be called multiple times safely.
+ */
 void LoggerManager::Shutdown() {
   if (std::atomic_exchange(&state_, State::kShutdown) == State::kShutdown)
     return;
@@ -153,6 +172,13 @@ void LoggerManager::RegisterLoggerBackendGenFunc(
   logger_backend_gen_func_map_.emplace(type, std::move(logger_backend_gen_func));
 }
 
+/**
+ * @brief Get a LoggerProxy for a given module.
+ * @param module_info Detailed information about the module.
+ * @return Reference to the LoggerProxy instance.
+ *
+ * This function retrieves or creates a LoggerProxy for the specified module.
+ */
 const LoggerProxy& LoggerManager::GetLoggerProxy(const util::ModuleDetailInfo& module_info) {
   AIMRT_CHECK_ERROR_THROW(
       state_.load() == State::kInit || state_.load() == State::kStart,
@@ -178,6 +204,13 @@ const LoggerProxy& LoggerManager::GetLoggerProxy(const util::ModuleDetailInfo& m
   return *(emplace_ret.first->second);
 }
 
+/**
+ * @brief Get a LoggerProxy by name.
+ * @param logger_name Name of the logger.
+ * @return Reference to the LoggerProxy instance.
+ *
+ * This function retrieves or creates a LoggerProxy with the given name.
+ */
 const LoggerProxy& LoggerManager::GetLoggerProxy(std::string_view logger_name) {
   AIMRT_CHECK_ERROR_THROW(
       state_.load() == State::kInit || state_.load() == State::kStart,

--- a/src/runtime/core/logger/logger_manager.h
+++ b/src/runtime/core/logger/logger_manager.h
@@ -97,7 +97,7 @@ class LoggerManager {
       std::equal_to<>>
       logger_proxy_map_;
 
-  std::mutex logger_proxy_map_mutex_;
+  mutable std::mutex logger_proxy_map_mutex_;  // 互斥锁，声明为 mutable
 };
 
 }  // namespace aimrt::runtime::core::logger

--- a/src/runtime/core/logger/logger_manager.h
+++ b/src/runtime/core/logger/logger_manager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <atomic>
 #include <memory>
 #include <unordered_map>
@@ -95,6 +96,8 @@ class LoggerManager {
       aimrt::common::util::StringHash,
       std::equal_to<>>
       logger_proxy_map_;
+
+  std::mutex logger_proxy_map_mutex_;
 };
 
 }  // namespace aimrt::runtime::core::logger


### PR DESCRIPTION
I've made some changes to improve thread safety in the `LoggerManager` class:

- **Added mutex locks**: I introduced `std::mutex` locks to protect access to shared resources like `logger_proxy_map_`. This should prevent race conditions when multiple threads access or modify the map.
- **Marked mutex as mutable**: To fix a compilation error when locking the mutex in a `const` function, I declared `logger_proxy_map_mutex_` as `mutable`. This allows us to lock the mutex even in `const` member functions.
- **Updated comments**: I updated the function comments to reflect these changes and to indicate that the functions are now thread-safe.

I ran ./tesh/sh on ubuntu in advance
```
Running tests...
Test project /home/fatin/Github-Fatin/AimRT/build
    Start 1: aimrt_common_util_test
1/5 Test #1: aimrt_common_util_test ............................   Passed    0.21 sec
    Start 2: aimrt_common_net_test
2/5 Test #2: aimrt_common_net_test .............................   Passed    1.14 sec
    Start 3: aimrt_interface_aimrt_module_cpp_interface_test
3/5 Test #3: aimrt_interface_aimrt_module_cpp_interface_test ...   Passed    0.00 sec
    Start 4: aimrt_runtime_core_test
4/5 Test #4: aimrt_runtime_core_test ...........................   Passed    1.44 sec
    Start 5: aimrt_plugins_ros2_plugin_test
5/5 Test #5: aimrt_plugins_ros2_plugin_test ....................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 5
```

my env:
```
- CMake: Version 3.30.5
- GCC/G++: GCC version 11.4.0-1ubuntu1~22.04), G++ version 11.4.0-1ubuntu1~22.04)
- pyinstaller: Version 6.11.0
- pip3: Installed
- Python 3: Version 3.10.12
- libssl-dev: Installed
- ROS2: Version humble
- build: Version 1.2.2.post1
- wheel: Version 0.44.0
- Make: Version 4.3
- pyyaml: Version 6.0.2
- setuptools: Version 75.3.0
- jinja2: Version 3.1.4
```