### PR TITLE
build: refactor CMake scripts to use functions for variable scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ cmake_minimum_required(VERSION 3.24)
 
 project(aimrt LANGUAGES C CXX)
 
+# Prevent variables from being reset by option
+# This setting allows predefined variables to take precedence for FetchContent_MakeAvailable()
+# see: https://cmake.org/cmake/help/latest/policy/CMP0077.html
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
 # Set cmake path
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/GetAsio.cmake
+++ b/cmake/GetAsio.cmake
@@ -22,61 +22,66 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(asio)
-if(NOT asio_POPULATED)
-  FetchContent_Populate(asio)
+# Wrap it in a function to restrict the scope of the variables
+function(get_asio)
+  FetchContent_GetProperties(asio)
+  if(NOT asio_POPULATED)
+    FetchContent_Populate(asio)
 
-  add_library(asio INTERFACE)
-  add_library(asio::asio ALIAS asio)
+    add_library(asio INTERFACE)
+    add_library(asio::asio ALIAS asio)
 
-  target_include_directories(asio INTERFACE $<BUILD_INTERFACE:${asio_SOURCE_DIR}/asio/include> $<INSTALL_INTERFACE:include/asio>)
-  target_compile_definitions(asio INTERFACE ASIO_STANDALONE ASIO_NO_DEPRECATED)
+    target_include_directories(asio INTERFACE $<BUILD_INTERFACE:${asio_SOURCE_DIR}/asio/include> $<INSTALL_INTERFACE:include/asio>)
+    target_compile_definitions(asio INTERFACE ASIO_STANDALONE ASIO_NO_DEPRECATED)
 
-  file(GLOB_RECURSE head_files ${asio_SOURCE_DIR}/asio/include/*.hpp ${asio_SOURCE_DIR}/asio/include/*.ipp)
-  target_sources(asio INTERFACE FILE_SET HEADERS BASE_DIRS ${asio_SOURCE_DIR}/asio/include FILES ${head_files})
+    file(GLOB_RECURSE head_files ${asio_SOURCE_DIR}/asio/include/*.hpp ${asio_SOURCE_DIR}/asio/include/*.ipp)
+    target_sources(asio INTERFACE FILE_SET HEADERS BASE_DIRS ${asio_SOURCE_DIR}/asio/include FILES ${head_files})
 
-  find_package(Threads REQUIRED)
-  target_link_libraries(asio INTERFACE Threads::Threads)
+    find_package(Threads REQUIRED)
+    target_link_libraries(asio INTERFACE Threads::Threads)
 
-  if(WIN32)
-    # macro see @ https://stackoverflow.com/a/40217291/1746503
-    macro(get_win32_winnt version)
-      if(CMAKE_SYSTEM_VERSION)
-        set(ver ${CMAKE_SYSTEM_VERSION})
-        string(REGEX MATCH "^([0-9]+).([0-9])" ver ${ver})
-        string(REGEX MATCH "^([0-9]+)" verMajor ${ver})
-        # Check for Windows 10, b/c we'll need to convert to hex 'A'.
-        if("${verMajor}" MATCHES "10")
-          set(verMajor "A")
-          string(REGEX REPLACE "^([0-9]+)" ${verMajor} ver ${ver})
-        endif("${verMajor}" MATCHES "10")
-        # Remove all remaining '.' characters.
-        string(REPLACE "." "" ver ${ver})
-        # Prepend each digit with a zero.
-        string(REGEX REPLACE "([0-9A-Z])" "0\\1" ver ${ver})
-        set(${version} "0x${ver}")
+    if(WIN32)
+      # macro see @ https://stackoverflow.com/a/40217291/1746503
+      macro(get_win32_winnt version)
+        if(CMAKE_SYSTEM_VERSION)
+          set(ver ${CMAKE_SYSTEM_VERSION})
+          string(REGEX MATCH "^([0-9]+).([0-9])" ver ${ver})
+          string(REGEX MATCH "^([0-9]+)" verMajor ${ver})
+          # Check for Windows 10, b/c we'll need to convert to hex 'A'.
+          if("${verMajor}" MATCHES "10")
+            set(verMajor "A")
+            string(REGEX REPLACE "^([0-9]+)" ${verMajor} ver ${ver})
+          endif("${verMajor}" MATCHES "10")
+          # Remove all remaining '.' characters.
+          string(REPLACE "." "" ver ${ver})
+          # Prepend each digit with a zero.
+          string(REGEX REPLACE "([0-9A-Z])" "0\\1" ver ${ver})
+          set(${version} "0x${ver}")
+        endif()
+      endmacro()
+
+      if(NOT DEFINED _WIN32_WINNT)
+        get_win32_winnt(ver)
+        set(_WIN32_WINNT ${ver})
       endif()
-    endmacro()
 
-    if(NOT DEFINED _WIN32_WINNT)
-      get_win32_winnt(ver)
-      set(_WIN32_WINNT ${ver})
+      message(STATUS "Set _WIN32_WINNET=${_WIN32_WINNT}")
+
+      target_compile_definitions(asio INTERFACE _WIN32_WINNT=${_WIN32_WINNT} WIN32_LEAN_AND_MEAN)
     endif()
 
-    message(STATUS "Set _WIN32_WINNET=${_WIN32_WINNT}")
+    set_property(TARGET asio PROPERTY EXPORT_NAME asio::asio)
+    install(
+      TARGETS asio
+      EXPORT asio-config
+      FILE_SET HEADERS
+      DESTINATION include/asio)
 
-    target_compile_definitions(asio INTERFACE _WIN32_WINNT=${_WIN32_WINNT} WIN32_LEAN_AND_MEAN)
+    install(EXPORT asio-config DESTINATION lib/cmake/asio)
   endif()
+endfunction()
 
-  set_property(TARGET asio PROPERTY EXPORT_NAME asio::asio)
-  install(
-    TARGETS asio
-    EXPORT asio-config
-    FILE_SET HEADERS
-    DESTINATION include/asio)
-
-  install(EXPORT asio-config DESTINATION lib/cmake/asio)
-endif()
+get_asio()
 
 # import targets：
 # asio::asio

--- a/cmake/GetBoost.cmake
+++ b/cmake/GetBoost.cmake
@@ -22,13 +22,16 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(boost)
-if(NOT boost_POPULATED)
-  set(BOOST_INCLUDE_LIBRARIES asio beast)
+# Wrap it in a function to restrict the scope of the variables
+function(get_boost)
+  FetchContent_GetProperties(boost)
+  if(NOT boost_POPULATED)
+    set(BOOST_INCLUDE_LIBRARIES asio beast)
 
-  set(Boost_USE_STATIC_LIBS
-      ON
-      CACHE BOOL "")
+    set(Boost_USE_STATIC_LIBS ON)
 
-  FetchContent_MakeAvailable(boost)
-endif()
+    FetchContent_MakeAvailable(boost)
+  endif()
+endfunction()
+
+get_boost()

--- a/cmake/GetCppToml.cmake
+++ b/cmake/GetCppToml.cmake
@@ -23,27 +23,32 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(cpptoml)
-if(NOT cpptoml_POPULATED)
-  FetchContent_Populate(cpptoml)
+# Wrap it in a function to restrict the scope of the variables
+function(get_cpptoml)
+  FetchContent_GetProperties(cpptoml)
+  if(NOT cpptoml_POPULATED)
+    FetchContent_Populate(cpptoml)
 
-  file(READ ${cpptoml_SOURCE_DIR}/include/cpptoml.h CPPTOML_TMP_VAR)
-  string(REPLACE "#include <cstring>" "#include <limits>" CPPTOML_TMP_VAR "${CPPTOML_TMP_VAR}")
-  file(WRITE ${cpptoml_SOURCE_DIR}/include/cpptoml.h "${CPPTOML_TMP_VAR}")
+    file(READ ${cpptoml_SOURCE_DIR}/include/cpptoml.h CPPTOML_TMP_VAR)
+    string(REPLACE "#include <cstring>" "#include <limits>" CPPTOML_TMP_VAR "${CPPTOML_TMP_VAR}")
+    file(WRITE ${cpptoml_SOURCE_DIR}/include/cpptoml.h "${CPPTOML_TMP_VAR}")
 
-  file(READ ${cpptoml_SOURCE_DIR}/cmake/cpptomlConfig.cmake.in CPPTOML_TMP_VAR)
-  string(REPLACE "\n" ";" CPPTOML_TMP_VAR_LINES "${CPPTOML_TMP_VAR}")
-  list(LENGTH CPPTOML_TMP_VAR_LINES CPPTOML_TMP_VAR_LINES_LENGTH)
-  if(CPPTOML_TMP_VAR_LINES_LENGTH GREATER 1)
-    list(REMOVE_AT CPPTOML_TMP_VAR_LINES 0)
+    file(READ ${cpptoml_SOURCE_DIR}/cmake/cpptomlConfig.cmake.in CPPTOML_TMP_VAR)
+    string(REPLACE "\n" ";" CPPTOML_TMP_VAR_LINES "${CPPTOML_TMP_VAR}")
+    list(LENGTH CPPTOML_TMP_VAR_LINES CPPTOML_TMP_VAR_LINES_LENGTH)
+    if(CPPTOML_TMP_VAR_LINES_LENGTH GREATER 1)
+      list(REMOVE_AT CPPTOML_TMP_VAR_LINES 0)
+    endif()
+    string(REPLACE ";" "\n" CPPTOML_TMP_VAR_LINES "${CPPTOML_TMP_VAR_LINES}")
+    file(WRITE ${cpptoml_SOURCE_DIR}/cmake/cpptomlConfig.cmake.in "${CPPTOML_TMP_VAR_LINES}")
+
+    file(READ ${cpptoml_SOURCE_DIR}/CMakeLists.txt CPPTOML_TMP_VAR)
+    string(REPLACE " ON" " OFF" CPPTOML_TMP_VAR "${CPPTOML_TMP_VAR}")
+    file(WRITE ${cpptoml_SOURCE_DIR}/CMakeLists.txt "${CPPTOML_TMP_VAR}")
+
+    add_subdirectory(${cpptoml_SOURCE_DIR} ${cpptoml_BINARY_DIR})
+
   endif()
-  string(REPLACE ";" "\n" CPPTOML_TMP_VAR_LINES "${CPPTOML_TMP_VAR_LINES}")
-  file(WRITE ${cpptoml_SOURCE_DIR}/cmake/cpptomlConfig.cmake.in "${CPPTOML_TMP_VAR_LINES}")
+endfunction()
 
-  file(READ ${cpptoml_SOURCE_DIR}/CMakeLists.txt CPPTOML_TMP_VAR)
-  string(REPLACE " ON" " OFF" CPPTOML_TMP_VAR "${CPPTOML_TMP_VAR}")
-  file(WRITE ${cpptoml_SOURCE_DIR}/CMakeLists.txt "${CPPTOML_TMP_VAR}")
-
-  add_subdirectory(${cpptoml_SOURCE_DIR} ${cpptoml_BINARY_DIR})
-
-endif()
+get_cpptoml()

--- a/cmake/GetFmt.cmake
+++ b/cmake/GetFmt.cmake
@@ -22,17 +22,19 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(fmt)
-if(NOT fmt_POPULATED)
-  set(FMT_MASTER_PROJECT
-      OFF
-      CACHE BOOL "")
-  set(FMT_INSTALL
-      ${AIMRT_INSTALL}
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_fmt)
+  FetchContent_GetProperties(fmt)
+  if(NOT fmt_POPULATED)
+    set(FMT_MASTER_PROJECT OFF)
 
-  FetchContent_MakeAvailable(fmt)
-endif()
+    set(FMT_INSTALL ON)
+
+    FetchContent_MakeAvailable(fmt)
+  endif()
+endfunction()
+
+get_fmt()
 
 # import targets：
 # fmt::fmt

--- a/cmake/GetGFlags.cmake
+++ b/cmake/GetGFlags.cmake
@@ -22,21 +22,24 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(gflags)
-if(NOT gflags_POPULATED)
-  FetchContent_Populate(gflags)
+# Wrap it in a function to restrict the scope of the variables
+function(get_gflags)
+  FetchContent_GetProperties(gflags)
+  if(NOT gflags_POPULATED)
+    FetchContent_Populate(gflags)
 
-  set(BUILD_TESTING
-      OFF
-      CACHE BOOL "")
+    set(BUILD_TESTING OFF)
 
-  file(READ ${gflags_SOURCE_DIR}/CMakeLists.txt TMP_VAR)
-  string(REPLACE "  set (PKGCONFIG_INSTALL_DIR " "# set (PKGCONFIG_INSTALL_DIR " TMP_VAR "${TMP_VAR}")
-  file(WRITE ${gflags_SOURCE_DIR}/CMakeLists.txt "${TMP_VAR}")
+    file(READ ${gflags_SOURCE_DIR}/CMakeLists.txt TMP_VAR)
+    string(REPLACE "  set (PKGCONFIG_INSTALL_DIR " "# set (PKGCONFIG_INSTALL_DIR " TMP_VAR "${TMP_VAR}")
+    file(WRITE ${gflags_SOURCE_DIR}/CMakeLists.txt "${TMP_VAR}")
 
-  add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
+    add_subdirectory(${gflags_SOURCE_DIR} ${gflags_BINARY_DIR})
 
-endif()
+  endif()
+endfunction()
+
+get_gflags()
 
 # import targets:
 # gflags::gflags

--- a/cmake/GetGTest.cmake
+++ b/cmake/GetGTest.cmake
@@ -22,19 +22,20 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  if(WIN32)
-    set(gtest_force_shared_crt
-        ON
-        CACHE BOOL "")
-  endif()
-  set(INSTALL_GTEST
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_googletest)
+  FetchContent_GetProperties(googletest)
+  if(NOT googletest_POPULATED)
+    if(WIN32)
+      set(gtest_force_shared_crt ON)
+    endif()
+    set(INSTALL_GTEST OFF)
 
-  FetchContent_MakeAvailable(googletest)
-endif()
+    FetchContent_MakeAvailable(googletest)
+  endif()
+endfunction()
+
+get_googletest()
 
 # import targets:
 # GTest::gtest

--- a/cmake/GetIceoryx.cmake
+++ b/cmake/GetIceoryx.cmake
@@ -25,12 +25,17 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(iceoryx)
-if(NOT iceoryx_POPULATED)
+# Wrap it in a function to restrict the scope of the variables
+function(get_iceoryx)
+  FetchContent_GetProperties(iceoryx)
+  if(NOT iceoryx_POPULATED)
 
-  FetchContent_Populate(iceoryx)
+    FetchContent_Populate(iceoryx)
 
-  # iceoryx‘s cmake file in ./iceoryx_meta
-  add_subdirectory(${iceoryx_SOURCE_DIR}/iceoryx_meta ${iceoryx_BINARY_DIR})
+    # iceoryx‘s cmake file in ./iceoryx_meta
+    add_subdirectory(${iceoryx_SOURCE_DIR}/iceoryx_meta ${iceoryx_BINARY_DIR})
 
-endif()
+  endif()
+endfunction()
+
+get_iceoryx()

--- a/cmake/GetJsonCpp.cmake
+++ b/cmake/GetJsonCpp.cmake
@@ -22,43 +22,35 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(jsoncpp)
-if(NOT jsoncpp_POPULATED)
-  set(JSONCPP_WITH_TESTS
-      OFF
-      CACHE BOOL "")
-  set(JSONCPP_WITH_POST_BUILD_UNITTEST
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_jsoncpp)
+  FetchContent_GetProperties(jsoncpp)
+  if(NOT jsoncpp_POPULATED)
+    set(JSONCPP_WITH_TESTS OFF)
 
-  set(BUILD_OBJECT_LIBS
-      OFF
-      CACHE BOOL "")
+    set(JSONCPP_WITH_POST_BUILD_UNITTEST OFF)
 
-  if(BUILD_SHARED_LIBS)
-    set(BUILD_SHARED_LIBS
-        ON
-        CACHE BOOL "")
-    set(BUILD_STATIC_LIBS
-        OFF
-        CACHE BOOL "")
-  else()
-    set(BUILD_SHARED_LIBS
-        OFF
-        CACHE BOOL "")
-    set(BUILD_STATIC_LIBS
-        ON
-        CACHE BOOL "")
+    set(BUILD_OBJECT_LIBS OFF)
+
+    if(BUILD_SHARED_LIBS)
+      set(BUILD_SHARED_LIBS ON)
+      set(BUILD_STATIC_LIBS OFF)
+    else()
+      set(BUILD_SHARED_LIBS OFF)
+      set(BUILD_STATIC_LIBS ON)
+    endif()
+
+    FetchContent_MakeAvailable(jsoncpp)
+
+    if(TARGET jsoncpp_static)
+      add_library(jsoncpp::jsoncpp ALIAS jsoncpp_static)
+    elseif(TARGET jsoncpp_lib)
+      add_library(jsoncpp::jsoncpp ALIAS jsoncpp_lib)
+    endif()
   endif()
+endfunction()
 
-  FetchContent_MakeAvailable(jsoncpp)
-
-  if(TARGET jsoncpp_static)
-    add_library(jsoncpp::jsoncpp ALIAS jsoncpp_static)
-  elseif(TARGET jsoncpp_lib)
-    add_library(jsoncpp::jsoncpp ALIAS jsoncpp_lib)
-  endif()
-endif()
+get_jsoncpp()
 
 # import targets:
 # jsoncpp::jsoncpp

--- a/cmake/GetLibUnifex.cmake
+++ b/cmake/GetLibUnifex.cmake
@@ -22,20 +22,23 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(libunifex)
-if(NOT libunifex_POPULATED)
-  set(UNIFEX_BUILD_EXAMPLES
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_libunifex)
+  FetchContent_GetProperties(libunifex)
+  if(NOT libunifex_POPULATED)
+    set(UNIFEX_BUILD_EXAMPLES OFF)
 
-  FetchContent_MakeAvailable(libunifex)
+    FetchContent_MakeAvailable(libunifex)
 
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(unifex PRIVATE -Wno-unused-but-set-variable)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+      target_compile_options(unifex PRIVATE -Wno-unused-but-set-variable)
+    endif()
+
+    add_library(unifex::unifex ALIAS unifex)
   endif()
+endfunction()
 
-  add_library(unifex::unifex ALIAS unifex)
-endif()
+get_libunifex()
 
 # import targets:
 # unifex::unifex

--- a/cmake/GetNghttp2.cmake
+++ b/cmake/GetNghttp2.cmake
@@ -22,22 +22,27 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(nghttp2)
-if(NOT nghttp2_POPULATED)
-  FetchContent_Populate(nghttp2)
+# Wrap it in a function to restrict the scope of the variables
+function(get_nghttp2)
+  FetchContent_GetProperties(nghttp2)
+  if(NOT nghttp2_POPULATED)
+    FetchContent_Populate(nghttp2)
 
-  set(BUILD_SHARED_LIBS OFF)
-  set(BUILD_STATIC_LIBS ON)
-  set(ENABLE_LIB_ONLY ON)
+    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_STATIC_LIBS ON)
+    set(ENABLE_LIB_ONLY ON)
 
-  # Avoid name conflict
-  set(nghttp2_CMAKE_FILE "${nghttp2_SOURCE_DIR}/CMakeLists.txt")
-  file(READ ${nghttp2_CMAKE_FILE} CONTENTS)
-  string(REPLACE "add_custom_target(check COMMAND \${CMAKE_CTEST_COMMAND})" "" NEW_CONTENTS "${CONTENTS}")
-  file(WRITE ${nghttp2_CMAKE_FILE} "${NEW_CONTENTS}")
+    # Avoid name conflict
+    set(nghttp2_CMAKE_FILE "${nghttp2_SOURCE_DIR}/CMakeLists.txt")
+    file(READ ${nghttp2_CMAKE_FILE} CONTENTS)
+    string(REPLACE "add_custom_target(check COMMAND \${CMAKE_CTEST_COMMAND})" "" NEW_CONTENTS "${CONTENTS}")
+    file(WRITE ${nghttp2_CMAKE_FILE} "${NEW_CONTENTS}")
 
-  add_subdirectory(${nghttp2_SOURCE_DIR} ${nghttp2_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+    add_subdirectory(${nghttp2_SOURCE_DIR} ${nghttp2_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
+endfunction()
+
+get_nghttp2()
 
 # import targets:
 # nghttp2::nghttp2

--- a/cmake/GetNlohmannJson.cmake
+++ b/cmake/GetNlohmannJson.cmake
@@ -22,10 +22,15 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(nlohmann_json)
-if(NOT nlohmann_json_POPULATED)
-  FetchContent_MakeAvailable(nlohmann_json)
-endif()
+# Wrap it in a function to restrict the scope of the variables
+function(get_nlohmann_json)
+  FetchContent_GetProperties(nlohmann_json)
+  if(NOT nlohmann_json_POPULATED)
+    FetchContent_MakeAvailable(nlohmann_json)
+  endif()
+endfunction()
+
+get_nlohmann_json()
 
 # import targets:
 # nlohmann_json::nlohmann_json

--- a/cmake/GetOpenTelemetryCpp.cmake
+++ b/cmake/GetOpenTelemetryCpp.cmake
@@ -18,105 +18,123 @@ else()
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
 endif()
 
-# Wrap it in a function to restrict the scope of the variables
-function(get_opentelemetry_cpp)
-  FetchContent_GetProperties(opentelemetry_cpp)
-  if(NOT opentelemetry_cpp_POPULATED)
-    set(BUILD_TESTING OFF)
+FetchContent_GetProperties(opentelemetry_cpp)
+if(NOT opentelemetry_cpp_POPULATED)
+  set(BUILD_TESTING
+      OFF
+      CACHE BOOL "")
 
-    set(WITH_BENCHMARK OFF)
+  set(WITH_BENCHMARK
+      OFF
+      CACHE BOOL "")
 
-    set(WITH_EXAMPLES OFF)
+  set(WITH_EXAMPLES
+      OFF
+      CACHE BOOL "")
 
-    set(WITH_FUNC_TESTS OFF)
+  set(WITH_FUNC_TESTS
+      OFF
+      CACHE BOOL "")
 
-    set(WITH_NO_DEPRECATED_CODE ON)
+  set(WITH_NO_DEPRECATED_CODE
+      ON
+      CACHE BOOL "")
 
-    set(WITH_DEPRECATED_SDK_FACTORY OFF)
+  set(WITH_DEPRECATED_SDK_FACTORY
+      OFF
+      CACHE BOOL "")
 
-    set(WITH_OTLP_HTTP ON)
+  set(WITH_OTLP_HTTP
+      ON
+      CACHE BOOL "")
 
-    set(WITH_STL "CXX20")
+  set(WITH_STL
+      "CXX20"
+      CACHE STRING "")
 
-    set(OTELCPP_PROTO_PATH ${opentelemetry_proto_SOURCE_DIR})
+  set(OTELCPP_PROTO_PATH
+      ${opentelemetry_proto_SOURCE_DIR}
+      CACHE PATH "")
 
-    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
+  set(PROTOBUF_PROTOC_EXECUTABLE
+      ${Protobuf_PROTOC_EXECUTABLE}
+      CACHE STRING "")
 
-    set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_SHARED_LIBS
+      OFF
+      CACHE BOOL "")
 
-    FetchContent_MakeAvailable(opentelemetry_cpp)
+  FetchContent_MakeAvailable(opentelemetry_cpp)
 
-    if(TARGET opentelemetry_api)
-      add_library(opentelemetry-cpp::api ALIAS opentelemetry_api)
-    endif()
-
-    if(TARGET opentelemetry_sdk)
-      add_library(opentelemetry-cpp::sdk ALIAS opentelemetry_sdk)
-    endif()
-
-    if(TARGET opentelemetry_ext)
-      add_library(opentelemetry-cpp::ext ALIAS opentelemetry_ext)
-    endif()
-
-    if(TARGET opentelemetry_version)
-      add_library(opentelemetry-cpp::version ALIAS opentelemetry_version)
-    endif()
-
-    if(TARGET opentelemetry_common)
-      add_library(opentelemetry-cpp::common ALIAS opentelemetry_common)
-    endif()
-
-    if(TARGET opentelemetry_trace)
-      add_library(opentelemetry-cpp::trace ALIAS opentelemetry_trace)
-    endif()
-
-    if(TARGET opentelemetry_metrics)
-      add_library(opentelemetry-cpp::metrics ALIAS opentelemetry_metrics)
-    endif()
-
-    if(TARGET opentelemetry_logs)
-      add_library(opentelemetry-cpp::logs ALIAS opentelemetry_logs)
-    endif()
-
-    if(TARGET opentelemetry_exporter_ostream_span)
-      add_library(opentelemetry-cpp::ostream_span_exporter ALIAS opentelemetry_exporter_ostream_span)
-    endif()
-
-    if(TARGET opentelemetry_exporter_ostream_metrics)
-      add_library(opentelemetry-cpp::ostream_metrics_exporter ALIAS opentelemetry_exporter_ostream_metrics)
-    endif()
-
-    if(TARGET opentelemetry_exporter_ostream_logs)
-      add_library(opentelemetry-cpp::ostream_log_record_exporter ALIAS opentelemetry_exporter_ostream_logs)
-    endif()
-
-    if(TARGET opentelemetry_otlp_recordable)
-      add_library(opentelemetry-cpp::otlp_recordable ALIAS opentelemetry_otlp_recordable)
-    endif()
-
-    if(TARGET opentelemetry_exporter_otlp_http_client)
-      add_library(opentelemetry-cpp::otlp_http_client ALIAS opentelemetry_exporter_otlp_http_client)
-    endif()
-
-    if(TARGET opentelemetry_exporter_otlp_http)
-      add_library(opentelemetry-cpp::otlp_http_exporter ALIAS opentelemetry_exporter_otlp_http)
-    endif()
-
-    if(TARGET opentelemetry_exporter_otlp_http_log)
-      add_library(opentelemetry-cpp::otlp_http_log_record_exporter ALIAS opentelemetry_exporter_otlp_http_log)
-    endif()
-
-    if(TARGET opentelemetry_exporter_otlp_http_metric)
-      add_library(opentelemetry-cpp::otlp_http_metric_exporter ALIAS opentelemetry_exporter_otlp_http_metric)
-    endif()
-
-    if(TARGET opentelemetry_http_client_curl)
-      add_library(opentelemetry-cpp::http_client_curl ALIAS opentelemetry_http_client_curl)
-    endif()
+  if(TARGET opentelemetry_api)
+    add_library(opentelemetry-cpp::api ALIAS opentelemetry_api)
   endif()
-endfunction()
 
-get_opentelemetry_cpp()
+  if(TARGET opentelemetry_sdk)
+    add_library(opentelemetry-cpp::sdk ALIAS opentelemetry_sdk)
+  endif()
+
+  if(TARGET opentelemetry_ext)
+    add_library(opentelemetry-cpp::ext ALIAS opentelemetry_ext)
+  endif()
+
+  if(TARGET opentelemetry_version)
+    add_library(opentelemetry-cpp::version ALIAS opentelemetry_version)
+  endif()
+
+  if(TARGET opentelemetry_common)
+    add_library(opentelemetry-cpp::common ALIAS opentelemetry_common)
+  endif()
+
+  if(TARGET opentelemetry_trace)
+    add_library(opentelemetry-cpp::trace ALIAS opentelemetry_trace)
+  endif()
+
+  if(TARGET opentelemetry_metrics)
+    add_library(opentelemetry-cpp::metrics ALIAS opentelemetry_metrics)
+  endif()
+
+  if(TARGET opentelemetry_logs)
+    add_library(opentelemetry-cpp::logs ALIAS opentelemetry_logs)
+  endif()
+
+  if(TARGET opentelemetry_exporter_ostream_span)
+    add_library(opentelemetry-cpp::ostream_span_exporter ALIAS opentelemetry_exporter_ostream_span)
+  endif()
+
+  if(TARGET opentelemetry_exporter_ostream_metrics)
+    add_library(opentelemetry-cpp::ostream_metrics_exporter ALIAS opentelemetry_exporter_ostream_metrics)
+  endif()
+
+  if(TARGET opentelemetry_exporter_ostream_logs)
+    add_library(opentelemetry-cpp::ostream_log_record_exporter ALIAS opentelemetry_exporter_ostream_logs)
+  endif()
+
+  if(TARGET opentelemetry_otlp_recordable)
+    add_library(opentelemetry-cpp::otlp_recordable ALIAS opentelemetry_otlp_recordable)
+  endif()
+
+  if(TARGET opentelemetry_exporter_otlp_http_client)
+    add_library(opentelemetry-cpp::otlp_http_client ALIAS opentelemetry_exporter_otlp_http_client)
+  endif()
+
+  if(TARGET opentelemetry_exporter_otlp_http)
+    add_library(opentelemetry-cpp::otlp_http_exporter ALIAS opentelemetry_exporter_otlp_http)
+  endif()
+
+  if(TARGET opentelemetry_exporter_otlp_http_log)
+    add_library(opentelemetry-cpp::otlp_http_log_record_exporter ALIAS opentelemetry_exporter_otlp_http_log)
+  endif()
+
+  if(TARGET opentelemetry_exporter_otlp_http_metric)
+    add_library(opentelemetry-cpp::otlp_http_metric_exporter ALIAS opentelemetry_exporter_otlp_http_metric)
+  endif()
+
+  if(TARGET opentelemetry_http_client_curl)
+    add_library(opentelemetry-cpp::http_client_curl ALIAS opentelemetry_http_client_curl)
+  endif()
+
+endif()
 
 # import targets:
 # opentelemetry-cpp::api

--- a/cmake/GetOpenTelemetryCpp.cmake
+++ b/cmake/GetOpenTelemetryCpp.cmake
@@ -18,123 +18,110 @@ else()
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
 endif()
 
-FetchContent_GetProperties(opentelemetry_cpp)
-if(NOT opentelemetry_cpp_POPULATED)
-  set(BUILD_TESTING
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_opentelemetry_cpp)
+  FetchContent_GetProperties(opentelemetry_cpp)
+  if(NOT opentelemetry_cpp_POPULATED)
+    set(BUILD_TESTING OFF)
 
-  set(WITH_BENCHMARK
-      OFF
-      CACHE BOOL "")
+    set(WITH_BENCHMARK OFF)
 
-  set(WITH_EXAMPLES
-      OFF
-      CACHE BOOL "")
+    set(WITH_EXAMPLES OFF)
 
-  set(WITH_FUNC_TESTS
-      OFF
-      CACHE BOOL "")
+    set(WITH_FUNC_TESTS OFF)
 
-  set(WITH_NO_DEPRECATED_CODE
-      ON
-      CACHE BOOL "")
+    set(WITH_NO_DEPRECATED_CODE ON)
 
-  set(WITH_DEPRECATED_SDK_FACTORY
-      OFF
-      CACHE BOOL "")
+    set(WITH_DEPRECATED_SDK_FACTORY OFF)
 
-  set(WITH_OTLP_HTTP
-      ON
-      CACHE BOOL "")
+    set(WITH_OTLP_HTTP ON)
 
-  set(WITH_STL
-      "CXX20"
-      CACHE STRING "")
+    set(WITH_STL
+        "CXX20"
+        CACHE STRING "")
 
-  set(OTELCPP_PROTO_PATH
-      ${opentelemetry_proto_SOURCE_DIR}
-      CACHE PATH "")
+    set(OTELCPP_PROTO_PATH
+        ${opentelemetry_proto_SOURCE_DIR}
+        CACHE PATH "")
 
-  set(PROTOBUF_PROTOC_EXECUTABLE
-      ${Protobuf_PROTOC_EXECUTABLE}
-      CACHE STRING "")
+    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
 
-  set(BUILD_SHARED_LIBS
-      OFF
-      CACHE BOOL "")
+    set(BUILD_SHARED_LIBS OFF)
 
-  FetchContent_MakeAvailable(opentelemetry_cpp)
+    FetchContent_MakeAvailable(opentelemetry_cpp)
 
-  if(TARGET opentelemetry_api)
-    add_library(opentelemetry-cpp::api ALIAS opentelemetry_api)
+    if(TARGET opentelemetry_api)
+      add_library(opentelemetry-cpp::api ALIAS opentelemetry_api)
+    endif()
+
+    if(TARGET opentelemetry_sdk)
+      add_library(opentelemetry-cpp::sdk ALIAS opentelemetry_sdk)
+    endif()
+
+    if(TARGET opentelemetry_ext)
+      add_library(opentelemetry-cpp::ext ALIAS opentelemetry_ext)
+    endif()
+
+    if(TARGET opentelemetry_version)
+      add_library(opentelemetry-cpp::version ALIAS opentelemetry_version)
+    endif()
+
+    if(TARGET opentelemetry_common)
+      add_library(opentelemetry-cpp::common ALIAS opentelemetry_common)
+    endif()
+
+    if(TARGET opentelemetry_trace)
+      add_library(opentelemetry-cpp::trace ALIAS opentelemetry_trace)
+    endif()
+
+    if(TARGET opentelemetry_metrics)
+      add_library(opentelemetry-cpp::metrics ALIAS opentelemetry_metrics)
+    endif()
+
+    if(TARGET opentelemetry_logs)
+      add_library(opentelemetry-cpp::logs ALIAS opentelemetry_logs)
+    endif()
+
+    if(TARGET opentelemetry_exporter_ostream_span)
+      add_library(opentelemetry-cpp::ostream_span_exporter ALIAS opentelemetry_exporter_ostream_span)
+    endif()
+
+    if(TARGET opentelemetry_exporter_ostream_metrics)
+      add_library(opentelemetry-cpp::ostream_metrics_exporter ALIAS opentelemetry_exporter_ostream_metrics)
+    endif()
+
+    if(TARGET opentelemetry_exporter_ostream_logs)
+      add_library(opentelemetry-cpp::ostream_log_record_exporter ALIAS opentelemetry_exporter_ostream_logs)
+    endif()
+
+    if(TARGET opentelemetry_otlp_recordable)
+      add_library(opentelemetry-cpp::otlp_recordable ALIAS opentelemetry_otlp_recordable)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http_client)
+      add_library(opentelemetry-cpp::otlp_http_client ALIAS opentelemetry_exporter_otlp_http_client)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http)
+      add_library(opentelemetry-cpp::otlp_http_exporter ALIAS opentelemetry_exporter_otlp_http)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http_log)
+      add_library(opentelemetry-cpp::otlp_http_log_record_exporter ALIAS opentelemetry_exporter_otlp_http_log)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http_metric)
+      add_library(opentelemetry-cpp::otlp_http_metric_exporter ALIAS opentelemetry_exporter_otlp_http_metric)
+    endif()
+
+    if(TARGET opentelemetry_http_client_curl)
+      add_library(opentelemetry-cpp::http_client_curl ALIAS opentelemetry_http_client_curl)
+    endif()
+
   endif()
+endfunction()
 
-  if(TARGET opentelemetry_sdk)
-    add_library(opentelemetry-cpp::sdk ALIAS opentelemetry_sdk)
-  endif()
-
-  if(TARGET opentelemetry_ext)
-    add_library(opentelemetry-cpp::ext ALIAS opentelemetry_ext)
-  endif()
-
-  if(TARGET opentelemetry_version)
-    add_library(opentelemetry-cpp::version ALIAS opentelemetry_version)
-  endif()
-
-  if(TARGET opentelemetry_common)
-    add_library(opentelemetry-cpp::common ALIAS opentelemetry_common)
-  endif()
-
-  if(TARGET opentelemetry_trace)
-    add_library(opentelemetry-cpp::trace ALIAS opentelemetry_trace)
-  endif()
-
-  if(TARGET opentelemetry_metrics)
-    add_library(opentelemetry-cpp::metrics ALIAS opentelemetry_metrics)
-  endif()
-
-  if(TARGET opentelemetry_logs)
-    add_library(opentelemetry-cpp::logs ALIAS opentelemetry_logs)
-  endif()
-
-  if(TARGET opentelemetry_exporter_ostream_span)
-    add_library(opentelemetry-cpp::ostream_span_exporter ALIAS opentelemetry_exporter_ostream_span)
-  endif()
-
-  if(TARGET opentelemetry_exporter_ostream_metrics)
-    add_library(opentelemetry-cpp::ostream_metrics_exporter ALIAS opentelemetry_exporter_ostream_metrics)
-  endif()
-
-  if(TARGET opentelemetry_exporter_ostream_logs)
-    add_library(opentelemetry-cpp::ostream_log_record_exporter ALIAS opentelemetry_exporter_ostream_logs)
-  endif()
-
-  if(TARGET opentelemetry_otlp_recordable)
-    add_library(opentelemetry-cpp::otlp_recordable ALIAS opentelemetry_otlp_recordable)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http_client)
-    add_library(opentelemetry-cpp::otlp_http_client ALIAS opentelemetry_exporter_otlp_http_client)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http)
-    add_library(opentelemetry-cpp::otlp_http_exporter ALIAS opentelemetry_exporter_otlp_http)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http_log)
-    add_library(opentelemetry-cpp::otlp_http_log_record_exporter ALIAS opentelemetry_exporter_otlp_http_log)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http_metric)
-    add_library(opentelemetry-cpp::otlp_http_metric_exporter ALIAS opentelemetry_exporter_otlp_http_metric)
-  endif()
-
-  if(TARGET opentelemetry_http_client_curl)
-    add_library(opentelemetry-cpp::http_client_curl ALIAS opentelemetry_http_client_curl)
-  endif()
-
-endif()
+get_opentelemetry_cpp()
 
 # import targets:
 # opentelemetry-cpp::api

--- a/cmake/GetOpenTelemetryCpp.cmake
+++ b/cmake/GetOpenTelemetryCpp.cmake
@@ -18,123 +18,105 @@ else()
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
 endif()
 
-FetchContent_GetProperties(opentelemetry_cpp)
-if(NOT opentelemetry_cpp_POPULATED)
-  set(BUILD_TESTING
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_opentelemetry_cpp)
+  FetchContent_GetProperties(opentelemetry_cpp)
+  if(NOT opentelemetry_cpp_POPULATED)
+    set(BUILD_TESTING OFF)
 
-  set(WITH_BENCHMARK
-      OFF
-      CACHE BOOL "")
+    set(WITH_BENCHMARK OFF)
 
-  set(WITH_EXAMPLES
-      OFF
-      CACHE BOOL "")
+    set(WITH_EXAMPLES OFF)
 
-  set(WITH_FUNC_TESTS
-      OFF
-      CACHE BOOL "")
+    set(WITH_FUNC_TESTS OFF)
 
-  set(WITH_NO_DEPRECATED_CODE
-      ON
-      CACHE BOOL "")
+    set(WITH_NO_DEPRECATED_CODE ON)
 
-  set(WITH_DEPRECATED_SDK_FACTORY
-      OFF
-      CACHE BOOL "")
+    set(WITH_DEPRECATED_SDK_FACTORY OFF)
 
-  set(WITH_OTLP_HTTP
-      ON
-      CACHE BOOL "")
+    set(WITH_OTLP_HTTP ON)
 
-  set(WITH_STL
-      "CXX20"
-      CACHE STRING "")
+    set(WITH_STL "CXX20")
 
-  set(OTELCPP_PROTO_PATH
-      ${opentelemetry_proto_SOURCE_DIR}
-      CACHE PATH "")
+    set(OTELCPP_PROTO_PATH ${opentelemetry_proto_SOURCE_DIR})
 
-  set(PROTOBUF_PROTOC_EXECUTABLE
-      ${Protobuf_PROTOC_EXECUTABLE}
-      CACHE STRING "")
+    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
 
-  set(BUILD_SHARED_LIBS
-      OFF
-      CACHE BOOL "")
+    set(BUILD_SHARED_LIBS OFF)
 
-  FetchContent_MakeAvailable(opentelemetry_cpp)
+    FetchContent_MakeAvailable(opentelemetry_cpp)
 
-  if(TARGET opentelemetry_api)
-    add_library(opentelemetry-cpp::api ALIAS opentelemetry_api)
+    if(TARGET opentelemetry_api)
+      add_library(opentelemetry-cpp::api ALIAS opentelemetry_api)
+    endif()
+
+    if(TARGET opentelemetry_sdk)
+      add_library(opentelemetry-cpp::sdk ALIAS opentelemetry_sdk)
+    endif()
+
+    if(TARGET opentelemetry_ext)
+      add_library(opentelemetry-cpp::ext ALIAS opentelemetry_ext)
+    endif()
+
+    if(TARGET opentelemetry_version)
+      add_library(opentelemetry-cpp::version ALIAS opentelemetry_version)
+    endif()
+
+    if(TARGET opentelemetry_common)
+      add_library(opentelemetry-cpp::common ALIAS opentelemetry_common)
+    endif()
+
+    if(TARGET opentelemetry_trace)
+      add_library(opentelemetry-cpp::trace ALIAS opentelemetry_trace)
+    endif()
+
+    if(TARGET opentelemetry_metrics)
+      add_library(opentelemetry-cpp::metrics ALIAS opentelemetry_metrics)
+    endif()
+
+    if(TARGET opentelemetry_logs)
+      add_library(opentelemetry-cpp::logs ALIAS opentelemetry_logs)
+    endif()
+
+    if(TARGET opentelemetry_exporter_ostream_span)
+      add_library(opentelemetry-cpp::ostream_span_exporter ALIAS opentelemetry_exporter_ostream_span)
+    endif()
+
+    if(TARGET opentelemetry_exporter_ostream_metrics)
+      add_library(opentelemetry-cpp::ostream_metrics_exporter ALIAS opentelemetry_exporter_ostream_metrics)
+    endif()
+
+    if(TARGET opentelemetry_exporter_ostream_logs)
+      add_library(opentelemetry-cpp::ostream_log_record_exporter ALIAS opentelemetry_exporter_ostream_logs)
+    endif()
+
+    if(TARGET opentelemetry_otlp_recordable)
+      add_library(opentelemetry-cpp::otlp_recordable ALIAS opentelemetry_otlp_recordable)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http_client)
+      add_library(opentelemetry-cpp::otlp_http_client ALIAS opentelemetry_exporter_otlp_http_client)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http)
+      add_library(opentelemetry-cpp::otlp_http_exporter ALIAS opentelemetry_exporter_otlp_http)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http_log)
+      add_library(opentelemetry-cpp::otlp_http_log_record_exporter ALIAS opentelemetry_exporter_otlp_http_log)
+    endif()
+
+    if(TARGET opentelemetry_exporter_otlp_http_metric)
+      add_library(opentelemetry-cpp::otlp_http_metric_exporter ALIAS opentelemetry_exporter_otlp_http_metric)
+    endif()
+
+    if(TARGET opentelemetry_http_client_curl)
+      add_library(opentelemetry-cpp::http_client_curl ALIAS opentelemetry_http_client_curl)
+    endif()
   endif()
+endfunction()
 
-  if(TARGET opentelemetry_sdk)
-    add_library(opentelemetry-cpp::sdk ALIAS opentelemetry_sdk)
-  endif()
-
-  if(TARGET opentelemetry_ext)
-    add_library(opentelemetry-cpp::ext ALIAS opentelemetry_ext)
-  endif()
-
-  if(TARGET opentelemetry_version)
-    add_library(opentelemetry-cpp::version ALIAS opentelemetry_version)
-  endif()
-
-  if(TARGET opentelemetry_common)
-    add_library(opentelemetry-cpp::common ALIAS opentelemetry_common)
-  endif()
-
-  if(TARGET opentelemetry_trace)
-    add_library(opentelemetry-cpp::trace ALIAS opentelemetry_trace)
-  endif()
-
-  if(TARGET opentelemetry_metrics)
-    add_library(opentelemetry-cpp::metrics ALIAS opentelemetry_metrics)
-  endif()
-
-  if(TARGET opentelemetry_logs)
-    add_library(opentelemetry-cpp::logs ALIAS opentelemetry_logs)
-  endif()
-
-  if(TARGET opentelemetry_exporter_ostream_span)
-    add_library(opentelemetry-cpp::ostream_span_exporter ALIAS opentelemetry_exporter_ostream_span)
-  endif()
-
-  if(TARGET opentelemetry_exporter_ostream_metrics)
-    add_library(opentelemetry-cpp::ostream_metrics_exporter ALIAS opentelemetry_exporter_ostream_metrics)
-  endif()
-
-  if(TARGET opentelemetry_exporter_ostream_logs)
-    add_library(opentelemetry-cpp::ostream_log_record_exporter ALIAS opentelemetry_exporter_ostream_logs)
-  endif()
-
-  if(TARGET opentelemetry_otlp_recordable)
-    add_library(opentelemetry-cpp::otlp_recordable ALIAS opentelemetry_otlp_recordable)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http_client)
-    add_library(opentelemetry-cpp::otlp_http_client ALIAS opentelemetry_exporter_otlp_http_client)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http)
-    add_library(opentelemetry-cpp::otlp_http_exporter ALIAS opentelemetry_exporter_otlp_http)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http_log)
-    add_library(opentelemetry-cpp::otlp_http_log_record_exporter ALIAS opentelemetry_exporter_otlp_http_log)
-  endif()
-
-  if(TARGET opentelemetry_exporter_otlp_http_metric)
-    add_library(opentelemetry-cpp::otlp_http_metric_exporter ALIAS opentelemetry_exporter_otlp_http_metric)
-  endif()
-
-  if(TARGET opentelemetry_http_client_curl)
-    add_library(opentelemetry-cpp::http_client_curl ALIAS opentelemetry_http_client_curl)
-  endif()
-
-endif()
+get_opentelemetry_cpp()
 
 # import targets:
 # opentelemetry-cpp::api

--- a/cmake/GetOpenTelemetryProto.cmake
+++ b/cmake/GetOpenTelemetryProto.cmake
@@ -18,7 +18,12 @@ else()
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
 endif()
 
-FetchContent_GetProperties(opentelemetry_proto)
-if(NOT opentelemetry_proto_POPULATED)
-  FetchContent_Populate(opentelemetry_proto)
-endif()
+# Wrap it in a function to restrict the scope of the variables
+function(get_opentelemetry_proto)
+  FetchContent_GetProperties(opentelemetry_proto)
+  if(NOT opentelemetry_proto_POPULATED)
+    FetchContent_Populate(opentelemetry_proto)
+  endif()
+endfunction()
+
+get_opentelemetry_proto()

--- a/cmake/GetOpenTelemetryProto.cmake
+++ b/cmake/GetOpenTelemetryProto.cmake
@@ -18,12 +18,7 @@ else()
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
 endif()
 
-# Wrap it in a function to restrict the scope of the variables
-function(get_opentelemetry_proto)
-  FetchContent_GetProperties(opentelemetry_proto)
-  if(NOT opentelemetry_proto_POPULATED)
-    FetchContent_Populate(opentelemetry_proto)
-  endif()
-endfunction()
-
-get_opentelemetry_proto()
+FetchContent_GetProperties(opentelemetry_proto)
+if(NOT opentelemetry_proto_POPULATED)
+  FetchContent_Populate(opentelemetry_proto)
+endif()

--- a/cmake/GetProtobuf.cmake
+++ b/cmake/GetProtobuf.cmake
@@ -22,35 +22,29 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(protobuf)
-if(NOT protobuf_POPULATED)
-  set(protobuf_BUILD_TESTS
-      OFF
-      CACHE BOOL "")
-  set(protobuf_BUILD_CONFORMANCE
-      OFF
-      CACHE BOOL "")
-  set(protobuf_BUILD_EXAMPLES
-      OFF
-      CACHE BOOL "")
-  set(protobuf_DISABLE_RTTI
-      OFF
-      CACHE BOOL "")
-  set(protobuf_WITH_ZLIB
-      OFF
-      CACHE BOOL "")
-  set(protobuf_MSVC_STATIC_RUNTIME
-      OFF
-      CACHE BOOL "")
-  set(protobuf_INSTALL
-      ${AIMRT_INSTALL}
-      CACHE BOOL "")
-  set(protobuf_VERBOSE
-      ON
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_protobuf)
+  FetchContent_GetProperties(protobuf)
+  if(NOT protobuf_POPULATED)
+    set(protobuf_BUILD_TESTS OFF)
 
-  FetchContent_MakeAvailable(protobuf)
-endif()
+    set(protobuf_BUILD_CONFORMANCE OFF)
+
+    set(protobuf_DISABLE_RTTI OFF)
+
+    set(protobuf_WITH_ZLIB OFF)
+
+    set(protobuf_MSVC_STATIC_RUNTIME OFF)
+
+    set(protobuf_INSTALL ${AIMRT_INSTALL})
+
+    set(protobuf_VERBOSE ON)
+
+    FetchContent_MakeAvailable(protobuf)
+  endif()
+endfunction()
+
+get_protobuf()
 
 # import targets:
 # protobuf::libprotobuf

--- a/cmake/GetPybind11.cmake
+++ b/cmake/GetPybind11.cmake
@@ -22,7 +22,12 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_MakeAvailable(pybind11)
-endif()
+# Wrap it in a function to restrict the scope of the variables
+function(get_pybind11)
+  FetchContent_GetProperties(pybind11)
+  if(NOT pybind11_POPULATED)
+    FetchContent_MakeAvailable(pybind11)
+  endif()
+endfunction()
+
+get_pybind11()

--- a/cmake/GetSqlite.cmake
+++ b/cmake/GetSqlite.cmake
@@ -23,24 +23,29 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(sqlite)
-if(NOT sqlite_POPULATED)
-  FetchContent_Populate(sqlite)
+# Wrap it in a function to restrict the scope of the variables
+function(get_sqlite)
+  FetchContent_GetProperties(sqlite)
+  if(NOT sqlite_POPULATED)
+    FetchContent_Populate(sqlite)
 
-  # sqlite lib
-  add_library(libsqlite)
-  add_library(sqlite::libsqlite ALIAS libsqlite)
+    # sqlite lib
+    add_library(libsqlite)
+    add_library(sqlite::libsqlite ALIAS libsqlite)
 
-  file(GLOB head_files ${sqlite_SOURCE_DIR}/*.h)
+    file(GLOB head_files ${sqlite_SOURCE_DIR}/*.h)
 
-  target_sources(libsqlite PRIVATE ${sqlite_SOURCE_DIR}/sqlite3.c)
-  target_include_directories(libsqlite PUBLIC $<BUILD_INTERFACE:${sqlite_SOURCE_DIR}>)
-  target_sources(libsqlite INTERFACE FILE_SET HEADERS BASE_DIRS ${sqlite_SOURCE_DIR} FILES ${head_files})
+    target_sources(libsqlite PRIVATE ${sqlite_SOURCE_DIR}/sqlite3.c)
+    target_include_directories(libsqlite PUBLIC $<BUILD_INTERFACE:${sqlite_SOURCE_DIR}>)
+    target_sources(libsqlite INTERFACE FILE_SET HEADERS BASE_DIRS ${sqlite_SOURCE_DIR} FILES ${head_files})
 
-  if(UNIX)
-    target_link_libraries(libsqlite PUBLIC pthread dl)
+    if(UNIX)
+      target_link_libraries(libsqlite PUBLIC pthread dl)
+    endif()
   endif()
-endif()
+endfunction()
+
+get_sqlite()
 
 # import targets:
 # sqlite::libsqlite

--- a/cmake/GetStdexec.cmake
+++ b/cmake/GetStdexec.cmake
@@ -22,22 +22,19 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(stdexec)
-if(NOT stdexec_POPULATED)
-  set(STDEXEC_ENABLE_IO_URING_TESTS
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_stdexec)
+  FetchContent_GetProperties(stdexec)
+  if(NOT stdexec_POPULATED)
+    set(STDEXEC_ENABLE_IO_URING_TESTS OFF)
+    set(STDEXEC_BUILD_EXAMPLES OFF)
+    set(STDEXEC_BUILD_TESTS OFF)
 
-  set(STDEXEC_BUILD_EXAMPLES
-      OFF
-      CACHE BOOL "")
+    FetchContent_MakeAvailable(stdexec)
+  endif()
+endfunction()
 
-  set(STDEXEC_BUILD_TESTS
-      OFF
-      CACHE BOOL "")
-
-  FetchContent_MakeAvailable(stdexec)
-endif()
+get_stdexec()
 
 # import targets:
 # STDEXEC::stdexec

--- a/cmake/GetTBB.cmake
+++ b/cmake/GetTBB.cmake
@@ -22,26 +22,23 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(tbb)
-if(NOT tbb_POPULATED)
-  set(TBB_TEST
-      OFF
-      CACHE BOOL "")
+# Wrap it in a function to restrict the scope of the variables
+function(get_tbb)
+  FetchContent_GetProperties(tbb)
+  if(NOT tbb_POPULATED)
+    set(TBB_TEST OFF)
 
-  set(TBB_DIR
-      ""
-      CACHE STRING "" FORCE)
+    set(TBB_DIR "")
 
-  set(TBB_INSTALL
-      ON
-      CACHE BOOL "")
+    set(TBB_INSTALL ON)
 
-  set(TBB_STRICT
-      OFF
-      CACHE BOOL "")
+    set(TBB_STRICT OFF)
 
-  FetchContent_MakeAvailable(tbb)
-endif()
+    FetchContent_MakeAvailable(tbb)
+  endif()
+endfunction()
+
+get_tbb()
 
 # import targets:
 # TBB::tbb

--- a/cmake/GetYamlCpp.cmake
+++ b/cmake/GetYamlCpp.cmake
@@ -22,28 +22,27 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(yaml-cpp)
-if(NOT yaml-cpp_POPULATED)
-  set(BUILD_TESTING
-      OFF
-      CACHE BOOL "")
-  set(YAML_CPP_BUILD_TESTS
-      OFF
-      CACHE BOOL "")
-  set(YAML_CPP_BUILD_TOOLS
-      OFF
-      CACHE BOOL "")
-  set(YAML_CPP_INSTALL
-      ON
-      CACHE BOOL "")
-  set(YAML_CPP_FORMAT_SOURCE
-      OFF
-      CACHE BOOL "")
-  set(YAML_CPP_BUILD_CONTRIB
-      OFF
-      CACHE BOOL "")
-  FetchContent_MakeAvailable(yaml-cpp)
-endif()
+# Wrap it in a function to restrict the scope of the variables
+function(get_yaml_cpp)
+  FetchContent_GetProperties(yaml-cpp)
+  if(NOT yaml-cpp_POPULATED)
+    set(BUILD_TESTING OFF)
+
+    set(YAML_CPP_BUILD_TESTS OFF)
+
+    set(YAML_CPP_BUILD_TOOLS OFF)
+
+    set(YAML_CPP_INSTALL ON)
+
+    set(YAML_CPP_FORMAT_SOURCE OFF)
+
+    set(YAML_CPP_BUILD_CONTRIB OFF)
+
+    FetchContent_MakeAvailable(yaml-cpp)
+  endif()
+endfunction()
+
+get_yaml_cpp()
 
 # import targets:
 # yaml-cpp::yaml-cpp

--- a/cmake/GetZenoh.cmake
+++ b/cmake/GetZenoh.cmake
@@ -23,7 +23,12 @@ else()
     OVERRIDE_FIND_PACKAGE)
 endif()
 
-FetchContent_GetProperties(zenohc)
-if(NOT zenohc_POPULATED)
-  FetchContent_MakeAvailable(zenohc)
-endif()
+# Wrap it in a function to restrict the scope of the variables
+function(get_zenohc)
+  FetchContent_GetProperties(zenohc)
+  if(NOT zenohc_POPULATED)
+    FetchContent_MakeAvailable(zenohc)
+  endif()
+endfunction()
+
+get_zenohc()


### PR DESCRIPTION
Wrap multiple CMake scripts in functions to restrict variable scope and prevent unintended resets. This ensures better modularity and maintainability in the build process while adhering to modern CMake best practices.