### PR TITLE
fix: add error handling for local protoc compiler detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ if(AIMRT_BUILD_WITH_ROS2)
       OFF
       CACHE BOOL "")
   include(GetJsonCpp)
+  include(GetYamlCpp)
   find_package(rclcpp REQUIRED)
   find_package(Python3 REQUIRED)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,10 +173,6 @@ if(AIMRT_BUILD_WITH_ROS2)
     cmake_policy(SET CMP0148 OLD)
   endif()
 
-  # fix gflag
-  set(BUILD_TESTING
-      OFF
-      CACHE BOOL "")
   include(GetJsonCpp)
   include(GetYamlCpp)
   find_package(rclcpp REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,9 +148,15 @@ if(AIMRT_BUILD_WITH_PROTOBUF)
   include(ProtobufGenCode)
 
   if(AIMRT_USE_LOCAL_PROTOC_COMPILER)
+    find_program(PROTOC_EXECUTABLE protoc)
+    if(NOT PROTOC_EXECUTABLE)
+      message(FATAL_ERROR "AIMRT_USE_LOCAL_PROTOC_COMPILER is ON, but can not find protoc compiler, " #
+                          "please install protoc and make it available in your PATH.")
+    endif()
+    message(STATUS "Found local protoc compiler: ${PROTOC_EXECUTABLE}")
     set(Protobuf_PROTOC_EXECUTABLE
-        "protoc"
-        CACHE STRING "Path to protoc compiler.")
+        ${PROTOC_EXECUTABLE}
+        CACHE STRING "Path to local protoc compiler.")
     add_executable(aimrt::protoc IMPORTED GLOBAL)
     set_target_properties(aimrt::protoc PROPERTIES IMPORTED_LOCATION ${Protobuf_PROTOC_EXECUTABLE})
     set_property(GLOBAL PROPERTY PROTOC_NAMESPACE_PROPERTY "aimrt")


### PR DESCRIPTION
Ensure that the local `protoc` compiler is found when `AIMRT_USE_LOCAL_PROTOC_COMPILER` is enabled. This improves setup reliability by providing clear feedback if `protoc` is missing, helping users avoid runtime issues.

Fix missing YamlCpp dependency when building with ROS2.

Closes #88 .