### PR TITLE
feat: add startup info printing during initialization

### DIFF
--- a/src/runtime/core/aimrt_core.cc
+++ b/src/runtime/core/aimrt_core.cc
@@ -25,6 +25,27 @@ AimRTCore::~AimRTCore() {
   hook_task_vec_array_.clear();
 }
 
+void AimRTCore::PrintStartupInfo() const {
+  constexpr const char* aimrt_info = R"(
+  ╔═══════════════════════════════════════════════════════════╗
+  ║                                                           ║
+  ║           █████╗ ██╗███╗   ███╗██████╗ ████████╗          ║
+  ║          ██╔══██╗██║████╗ ████║██╔══██╗╚══██╔══╝          ║
+  ║          ███████║██║██╔████╔██║██████╔╝   ██║             ║
+  ║          ██╔══██║██║██║╚██╔╝██║██╔══██╗   ██║             ║
+  ║          ██║  ██║██║██║ ╚═╝ ██║██║  ██║   ██║             ║
+  ║          ╚═╝  ╚═╝╚═╝╚═╝     ╚═╝╚═╝  ╚═╝   ╚═╝             ║
+  ║                                                           ║
+  ║        Modern High Performance Robotics Framework         ║
+  ║        Official Website: https://aimrt.org                ║
+  ║        Documentation:    https://docs.aimrt.org           ║
+  ║        Version:          v{:<32}║
+  ╚═══════════════════════════════════════════════════════════╝
+  )";
+  constexpr const auto* version_str = util::GetAimRTVersion();
+  AIMRT_INFO(aimrt_info, version_str);
+}
+
 void AimRTCore::Initialize(const Options& options) {
   EnterState(State::kPreInit);
 
@@ -70,6 +91,7 @@ void AimRTCore::Initialize(const Options& options) {
       std::bind(&AimRTCore::GetExecutor, this, std::placeholders::_1));
   logger_manager_.Initialize(configurator_manager_.GetAimRTOptionsNode("log"));
   SetCoreLogger();
+  PrintStartupInfo();
   EnterState(State::kPostInitLog);
 
   // Init allocator

--- a/src/runtime/core/aimrt_core.h
+++ b/src/runtime/core/aimrt_core.h
@@ -214,6 +214,7 @@ class AimRTCore {
   void CheckCfgFile() const;
   void StartImpl();
   void ShutdownImpl();
+  void PrintStartupInfo() const;
 
  private:
   Options options_;

--- a/src/runtime/core/util/version.h
+++ b/src/runtime/core/util/version.h
@@ -5,7 +5,7 @@
 
 namespace aimrt::runtime::core::util {
 
-inline const char* GetAimRTVersion() {
+constexpr const char* GetAimRTVersion() {
   return AIMRT_VERSION;
 }
 }  // namespace aimrt::runtime::core::util


### PR DESCRIPTION
Include a method to print detailed startup information about the framework, enhancing user awareness of the version and providing relevant links for support.

Close #106 .