### PR TITLE
fix: enhance error checking for server listen address in gRPC plugin

### DIFF
--- a/src/examples/plugins/grpc_plugin/install/linux/bin/start_examples_plugins_grpc_plugin_pb_rpc_client.sh
+++ b/src/examples/plugins/grpc_plugin/install/linux/bin/start_examples_plugins_grpc_plugin_pb_rpc_client.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-lsof -i :50051 | awk 'NR!=1 {print $2}' | xargs kill -9
-
 ./aimrt_main --cfg_file_path=./cfg/examples_plugins_grpc_plugin_pb_rpc_client_cfg.yaml

--- a/src/examples/plugins/grpc_plugin/install/linux/bin/start_examples_plugins_grpc_plugin_pb_rpc_server.sh
+++ b/src/examples/plugins/grpc_plugin/install/linux/bin/start_examples_plugins_grpc_plugin_pb_rpc_server.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-lsof -i :50050 | awk 'NR!=1 {print $2}' | xargs kill -9
-
 ./aimrt_main --cfg_file_path=./cfg/examples_plugins_grpc_plugin_pb_rpc_server_cfg.yaml

--- a/src/plugins/grpc_plugin/server/server.h
+++ b/src/plugins/grpc_plugin/server/server.h
@@ -67,6 +67,9 @@ class AsioHttp2Server : public std::enable_shared_from_this<AsioHttp2Server> {
 
     options_ = ServerOptions::Verify(options);
     connection_options_ptr_ = std::make_shared<ConnectionOptions>(options_);
+
+    AIMRT_CHECK_ERROR_THROW(CheckListenAddr(options_.ep),
+                            "{} is already in use.", aimrt::common::util::SSToString(options_.ep));
   }
 
   void Start() {
@@ -171,6 +174,17 @@ class AsioHttp2Server : public std::enable_shared_from_this<AsioHttp2Server> {
     }
 
     connection_ptr_list_.clear();
+  }
+
+ private:
+  static bool CheckListenAddr(const boost::asio::ip::tcp::endpoint& ep) {
+    try {
+      IOCtx io;
+      Tcp::acceptor acceptor(io, ep);
+      return true;
+    } catch (...) {
+      return false;
+    }
   }
 
  private:


### PR DESCRIPTION
- Added a new method `CheckListenAddr` to validate the listening address for the server.
- Integrated error checking in the server initialization to throw an exception if the address is already in use, improving robustness and error handling.
- Eliminated the lines that forcefully kill processes listening on ports 50050 and 50051 in the gRPC plugin start scripts. This change simplifies the startup process and avoids potential issues with abrupt terminations.
