### PR TITLE
fix: change string_view to string in LocalChannelBackend subscription index map

### DIFF
--- a/src/runtime/core/channel/local_channel_backend.h
+++ b/src/runtime/core/channel/local_channel_backend.h
@@ -67,13 +67,13 @@ class LocalChannelBackend : public ChannelBackendBase {
 
   using SubscribeIndexMap =
       std::unordered_map<
-          std::string_view,  // msg_type
+          std::string,  // msg_type
           std::unordered_map<
-              std::string_view,  // topic
+              std::string,  // topic
               std::unordered_map<
-                  std::string_view,  // lib_path
+                  std::string,  // lib_path
                   std::unordered_set<
-                      std::string_view>>>>;  // module_name
+                      std::string>>>>;  // module_name
   SubscribeIndexMap subscribe_index_map_;
 };
 


### PR DESCRIPTION
Updated the SubscribeIndexMap in LocalChannelBackend to use std::string instead of std::string_view for msg_type, topic, lib_path, and module_name. This change enhances memory management and ensures proper ownership semantics for string data within the subscription index map.