### PR TITLE
docs: update Windows build instructions and clarify installation methods

### DIFF
--- a/document/sphinx-cn/tutorials/quick_start/build_from_source_windows.md
+++ b/document/sphinx-cn/tutorials/quick_start/build_from_source_windows.md
@@ -9,6 +9,8 @@
 
 当前 AimRT 支持的 MSVC 编译套件版本为 1940，推荐直接安装 [Visual Studio 2022](https://visualstudio.microsoft.com/zh-hans/downloads/) 及以上版本，安装时勾选 C++ 桌面开发模块。
 
+注意 Visual Studio 2022 的 MSVC 工具集在 2024 年 5 月更新到了 19.40 版本， 早期版本低于 19.40 的 MSVC 工具集可能存在编译问题。
+
 ### CMake
 
 当前 AimRT 支持的最低 CMake 版本为 3.24，可以通过 [CMake 官方网站](https://cmake.org/download/)下载合适的版本进行安装：

--- a/document/sphinx-cn/tutorials/quick_start/installation_py.md
+++ b/document/sphinx-cn/tutorials/quick_start/installation_py.md
@@ -2,9 +2,9 @@
 
 AimRT Python 接口通过 `aimrt_py` 包来使用。您可以通过三种方式安装获取 `aimrt_py` 包：
 
-- 基于 pip install 安装；
+- 【暂不支持】PyPI 安装；
 - 二进制安装；
-- [推荐] 基于源码编译安装；
+- 源码编译安装；
 
 ## Python 环境要求
 


### PR DESCRIPTION
- Added a note regarding the MSVC toolset version 19.40 for Visual Studio 2022 to address potential compilation issues.
- Updated the installation methods for the `aimrt_py` package, clarifying that PyPI installation is not currently supported and emphasizing source compilation as the recommended method.