### PR TITLE
fix: adjust context handling in ROS2 adapter RPC client and server

### DIFF
--- a/src/plugins/ros2_plugin/ros2_adapter_rpc_client.cc
+++ b/src/plugins/ros2_plugin/ros2_adapter_rpc_client.cc
@@ -245,7 +245,8 @@ void Ros2AdapterWrapperClient::Invoke(
   wrapper_req.serialization_type = serialization_type;
 
   const auto& keys = client_invoke_wrapper_ptr->ctx_ref.GetMetaKeys();
-  wrapper_req.context.reserve(2 * keys.size());
+  wrapper_req.context.reserve(2 * keys.size() + 1);
+  wrapper_req.context.emplace_back(std::to_string(client_invoke_wrapper_ptr->ctx_ref.Timeout().count()));
   for (const auto& key : keys) {
     wrapper_req.context.emplace_back(key);
     wrapper_req.context.emplace_back(client_invoke_wrapper_ptr->ctx_ref.GetMetaValue(key));

--- a/src/plugins/ros2_plugin/ros2_adapter_rpc_client.cc
+++ b/src/plugins/ros2_plugin/ros2_adapter_rpc_client.cc
@@ -245,7 +245,8 @@ void Ros2AdapterWrapperClient::Invoke(
   wrapper_req.serialization_type = serialization_type;
 
   const auto& keys = client_invoke_wrapper_ptr->ctx_ref.GetMetaKeys();
-  wrapper_req.context.reserve(2 * keys.size() + 1);
+  wrapper_req.context.reserve(2 * (keys.size() + 1));
+  wrapper_req.context.emplace_back("aimrt-timeout");
   wrapper_req.context.emplace_back(std::to_string(client_invoke_wrapper_ptr->ctx_ref.Timeout().count()));
   for (const auto& key : keys) {
     wrapper_req.context.emplace_back(key);

--- a/src/plugins/ros2_plugin/ros2_adapter_rpc_server.cc
+++ b/src/plugins/ros2_plugin/ros2_adapter_rpc_server.cc
@@ -204,12 +204,13 @@ void Ros2AdapterWrapperServer::handle_request(
   // 获取字段
   auto& wrapper_req = *(static_cast<ros2_plugin_proto::srv::RosRpcWrapper::Request*>(request.get()));
 
-  ctx_ptr->SetTimeout(std::chrono::nanoseconds(std::stoll(wrapper_req.context[0])));
-
-  size_t context_size = (wrapper_req.context.size() - 1) / 2;
-  for (size_t ii = 0; ii < context_size; ++ii) {
-    const auto& key = wrapper_req.context[ii * 2 + 1];
-    const auto& val = wrapper_req.context[ii * 2 + 2];
+  for (size_t ii = 0; ii + 1 < wrapper_req.context.size(); ii += 2) {
+    const auto& key = wrapper_req.context[ii];
+    const auto& val = wrapper_req.context[ii + 1];
+    if (ii == 0 && key == "aimrt-timeout") {
+      ctx_ptr->SetTimeout(std::chrono::nanoseconds(std::stoll(val)));
+      continue;
+    }
     ctx_ptr->SetMetaValue(key, val);
   }
 

--- a/src/plugins/ros2_plugin/ros2_adapter_rpc_server.cc
+++ b/src/plugins/ros2_plugin/ros2_adapter_rpc_server.cc
@@ -204,10 +204,12 @@ void Ros2AdapterWrapperServer::handle_request(
   // 获取字段
   auto& wrapper_req = *(static_cast<ros2_plugin_proto::srv::RosRpcWrapper::Request*>(request.get()));
 
-  size_t context_size = wrapper_req.context.size() / 2;
+  ctx_ptr->SetTimeout(std::chrono::nanoseconds(std::stoll(wrapper_req.context[0])));
+
+  size_t context_size = (wrapper_req.context.size() - 1) / 2;
   for (size_t ii = 0; ii < context_size; ++ii) {
-    const auto& key = wrapper_req.context[ii * 2];
-    const auto& val = wrapper_req.context[ii * 2 + 1];
+    const auto& key = wrapper_req.context[ii * 2 + 1];
+    const auto& val = wrapper_req.context[ii * 2 + 2];
     ctx_ptr->SetMetaValue(key, val);
   }
 


### PR DESCRIPTION
- Updated the context reservation in `ros2_adapter_rpc_client.cc` to accommodate an additional timeout value.
- Modified the context parsing in `ros2_adapter_rpc_server.cc` to correctly handle the new timeout value and adjust the indexing for key-value pairs accordingly.