### PR TITLE
feat: dynamically read package version from VERSION file in example runner

### DIFF
--- a/src/examples/utils/run_all_example.py
+++ b/src/examples/utils/run_all_example.py
@@ -31,8 +31,14 @@ class ExampleRunner:
 
         if self.args.save is not None:
             self.check_and_create_directory(self.args.save)  # todo ...
+
+        # Read version from VERSION file
+        version_file = os.path.join(default_build_path, "..", "VERSION")
+        with open(version_file, "r") as f:
+            version = f.read().strip()
+
         subprocess.run(
-            ["pip3", "install", "./aimrt_py_pkg/dist/aimrt_py-0.10.0-cp310-cp310-linux_x86_64.whl", "--force-reinstall"],
+            ["pip3", "install", f"./aimrt_py_pkg/dist/aimrt_py-{version}-cp310-cp310-linux_x86_64.whl", "--force-reinstall"],
             cwd=default_build_path,
         )
         subprocess.run(


### PR DESCRIPTION
- Updated the ExampleRunner class in run_all_example.py to read the package version from the VERSION file instead of hardcoding it. This change enhances flexibility and ensures that the correct version is installed during the example execution.