### PR TITLE
fix: improve MQTT connection failure logging

### DIFF
--- a/src/plugins/mqtt_plugin/mqtt_plugin.cc
+++ b/src/plugins/mqtt_plugin/mqtt_plugin.cc
@@ -209,8 +209,7 @@ void MqttPlugin::AsyncConnect() {
 
   // if connect failed, call connect again
   conn_opts.onFailure = [](void *context, MQTTAsync_failureData *response) {
-    AIMRT_WARN("Failed to connect mqtt broker, code: {}, msg: {}",
-               response->code, response->message);
+    AIMRT_WARN("Failed to connect mqtt broker: {}", (!response || !response->message) ? "Unknown error" : response->message);
     auto *mqtt_plugin_ptr = static_cast<MqttPlugin *>(context);
     std::this_thread::sleep_for(std::chrono::milliseconds(mqtt_plugin_ptr->options_.reconnect_interval_ms));
     mqtt_plugin_ptr->AsyncConnect();


### PR DESCRIPTION
- Enhanced the error logging in the MQTT plugin to provide clearer messages when connection attempts fail.
- Updated the failure callback to handle cases where the response message may be null, ensuring that a more informative message is logged.