### PR TITLE
fix: add CMake policy for consistent configuration

### DIFF
--- a/document/sphinx-cn/tutorials/quick_start/helloworld_cpp.md
+++ b/document/sphinx-cn/tutorials/quick_start/helloworld_cpp.md
@@ -64,6 +64,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
 include(cmake/GetAimRT.cmake)
 
 add_subdirectory(src)


### PR DESCRIPTION
Add `CMAKE_POLICY_DEFAULT_CMP0077` to ensure consistent CMake configuration behavior across different environments