### PR TITLE
fix: improve NormalPublisherModule start and shutdown logic

### DIFF
--- a/src/examples/cpp/pb_chn/module/normal_publisher_module/normal_publisher_module.cc
+++ b/src/examples/cpp/pb_chn/module/normal_publisher_module/normal_publisher_module.cc
@@ -47,6 +47,7 @@ bool NormalPublisherModule::Initialize(aimrt::CoreRef core) {
 
 bool NormalPublisherModule::Start() {
   try {
+    run_flag_ = true;
     executor_.Execute(std::bind(&NormalPublisherModule::MainLoop, this));
   } catch (const std::exception& e) {
     AIMRT_ERROR("Start failed, {}", e.what());
@@ -59,8 +60,10 @@ bool NormalPublisherModule::Start() {
 
 void NormalPublisherModule::Shutdown() {
   try {
-    run_flag_ = false;
-    stop_sig_.get_future().wait();
+    if (run_flag_) {
+      run_flag_ = false;
+      stop_sig_.get_future().wait();
+    }
   } catch (const std::exception& e) {
     AIMRT_ERROR("Shutdown failed, {}", e.what());
     return;

--- a/src/examples/cpp/pb_chn/module/normal_publisher_module/normal_publisher_module.h
+++ b/src/examples/cpp/pb_chn/module/normal_publisher_module/normal_publisher_module.h
@@ -34,7 +34,7 @@ class NormalPublisherModule : public aimrt::ModuleBase {
   aimrt::CoreRef core_;
   aimrt::executor::ExecutorRef executor_;
 
-  std::atomic_bool run_flag_ = true;
+  std::atomic_bool run_flag_ = false;
   std::promise<void> stop_sig_;
 
   std::string topic_name_ = "test_topic";


### PR DESCRIPTION
- Initialize `run_flag_` to false by default
- Set `run_flag_` to true when starting the module
- Add a check in Shutdown to prevent unnecessary future waiting