### PR TITLE
fix: make python examples and benchmark work as before

### DIFF
--- a/src/examples/py/pb_chn/build_examples_py_pb_chn.sh
+++ b/src/examples/py/pb_chn/build_examples_py_pb_chn.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 protoc_cmd=protoc
-protocols_dir=../../../protocols/example/
+protocols_dir=../../../protocols/pb/example/
 
 if ! command -v ${protoc_cmd} &> /dev/null; then
     echo "Can not find protoc!"

--- a/src/examples/py/pb_chn_bench/README.md
+++ b/src/examples/py/pb_chn_bench/README.md
@@ -7,7 +7,7 @@
 - 如何使用 http 类型的 channel 后端；
 
 核心代码：
-- [benchmark.proto](../../../protocols/example/benchmark.proto)
+- [benchmark.proto](../../../protocols/pb/example/benchmark.proto)
 - [benchmark_publisher_module.py](./benchmark_publisher_module.py)
 - [benchmark_publisher_app.py](./benchmark_publisher_app.py)
 - [benchmark_subscriber_module.py](./benchmark_subscriber_module.py)

--- a/src/examples/py/pb_chn_bench/benchmark_subscriber_module.py
+++ b/src/examples/py/pb_chn_bench/benchmark_subscriber_module.py
@@ -162,7 +162,7 @@ class BenchmarkSubscriber(aimrt_py.ModuleBase):
         avg_latency = sum(latency_vec) / recv_count
 
         result_str = f"Benchmark plan {self.cur_bench_plan.bench_plan_id} completed, report:"
-        result_str += f"\nmode: {self.cur_bench_plan.perf_mode}"
+        result_str += f"\nmode: {self.cur_bench_plan.mode}"
         result_str += f"\nfrequency: {self.cur_bench_plan.send_frequency} hz"
         result_str += f"\ntopic number: {self.cur_bench_plan.topic_number}"
         result_str += f"\nparallel number: {self.cur_bench_plan.parallel_number}"

--- a/src/examples/py/pb_chn_bench/build_py_pb_chn.sh
+++ b/src/examples/py/pb_chn_bench/build_py_pb_chn.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 protoc_cmd=protoc
-protocols_dir=../../../protocols/example/
+protocols_dir=../../../protocols/pb/example/
 
 if ! command -v ${protoc_cmd} &> /dev/null; then
     echo "Can not find protoc!"

--- a/src/examples/py/pb_rpc/build_examples_py_pb_rpc.sh
+++ b/src/examples/py/pb_rpc/build_examples_py_pb_rpc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 protoc_cmd=protoc
-protocols_dir=../../../protocols/example/
+protocols_dir=../../../protocols/pb/example/
 
 if ! command -v ${protoc_cmd} &> /dev/null; then
     echo "Can not find protoc!"

--- a/src/examples/py/pb_rpc_bench/build_examples_py_pb_rpc_bench.sh
+++ b/src/examples/py/pb_rpc_bench/build_examples_py_pb_rpc_bench.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 protoc_cmd=protoc
-protocols_dir=../../../protocols/example/
+protocols_dir=../../../protocols/pb/example/
 
 if ! command -v ${protoc_cmd} &> /dev/null; then
     echo "Can not find protoc!"

--- a/src/examples/py/ros2_rpc/README.md
+++ b/src/examples/py/ros2_rpc/README.md
@@ -11,7 +11,7 @@
 
 
 核心代码：
-- [RosTestRpc.srv](../../../protocols/example_ros2/srv/RosTestRpc.srv)
+- [RosTestRpc.srv](../../../protocols/ros2/example_ros2/srv/RosTestRpc.srv)
 - [examples_py_ros2_rpc_client_app.py](./examples_py_ros2_rpc_client_app.py)
 - [examples_py_ros2_rpc_server_app.py](./examples_py_ros2_rpc_server_app.py)
 
@@ -49,7 +49,7 @@
 
 
 核心代码：
-- [RosTestRpc.srv](../../../protocols/example_ros2/srv/RosTestRpc.srv)
+- [RosTestRpc.srv](../../../protocols/ros2/example_ros2/srv/RosTestRpc.srv)
 - [examples_py_ros2_rpc_client_app.py](./examples_py_ros2_rpc_client_app.py)
 - [examples_py_ros2_rpc_server_app.py](./examples_py_ros2_rpc_server_app.py)
 
@@ -88,7 +88,7 @@
 
 
 核心代码：
-- [RosTestRpc.srv](../../../protocols/example_ros2/srv/RosTestRpc.srv)
+- [RosTestRpc.srv](../../../protocols/ros2/example_ros2/srv/RosTestRpc.srv)
 - [examples_py_ros2_rpc_client_app.py](./examples_py_ros2_rpc_client_app.py)
 - [examples_py_ros2_rpc_server_app.py](./examples_py_ros2_rpc_server_app.py)
 

--- a/src/examples/py/ros2_rpc/build_examples_py_ros2_rpc.sh
+++ b/src/examples/py/ros2_rpc/build_examples_py_ros2_rpc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-protocols_dir=../../../protocols/example_ros2/
+protocols_dir=../../../protocols/ros2/example_ros2/
 
 aimrt_py-gen-ros2-rpc --pkg_name=example_ros2 --srv_file=${protocols_dir}/RosTestRpc.srv --output_path=./


### PR DESCRIPTION
- Adapt examples protocols to new path introduced by #248 .
- Fix broken benchmark introduced by #246 .