### PR TITLE
refactor: conditionally enable installation for some dependencies

### DIFF
--- a/cmake/GetAsio.cmake
+++ b/cmake/GetAsio.cmake
@@ -71,13 +71,15 @@ function(get_asio)
     endif()
 
     set_property(TARGET asio PROPERTY EXPORT_NAME asio::asio)
-    install(
-      TARGETS asio
-      EXPORT asio-config
-      FILE_SET HEADERS
-      DESTINATION include/asio)
+    if(AIMRT_INSTALL)
+      install(
+        TARGETS asio
+        EXPORT asio-config
+        FILE_SET HEADERS
+        DESTINATION include/asio)
 
-    install(EXPORT asio-config DESTINATION lib/cmake/asio)
+      install(EXPORT asio-config DESTINATION lib/cmake/asio)
+    endif()
   endif()
 endfunction()
 

--- a/cmake/GetFmt.cmake
+++ b/cmake/GetFmt.cmake
@@ -28,7 +28,7 @@ function(get_fmt)
   if(NOT fmt_POPULATED)
     set(FMT_MASTER_PROJECT OFF)
 
-    set(FMT_INSTALL ON)
+    set(FMT_INSTALL ${AIMRT_INSTALL})
 
     FetchContent_MakeAvailable(fmt)
   endif()

--- a/cmake/GetTBB.cmake
+++ b/cmake/GetTBB.cmake
@@ -30,7 +30,7 @@ function(get_tbb)
 
     set(TBB_DIR "")
 
-    set(TBB_INSTALL ON)
+    set(TBB_INSTALL ${AIMRT_INSTALL})
 
     set(TBB_STRICT OFF)
 

--- a/cmake/GetYamlCpp.cmake
+++ b/cmake/GetYamlCpp.cmake
@@ -32,7 +32,7 @@ function(get_yaml_cpp)
 
     set(YAML_CPP_BUILD_TOOLS OFF)
 
-    set(YAML_CPP_INSTALL ON)
+    set(YAML_CPP_INSTALL ${AIMRT_INSTALL})
 
     set(YAML_CPP_FORMAT_SOURCE OFF)
 


### PR DESCRIPTION
Only Asio, fmt, Tbb, and YamlCpp supports it.
Paho-mqtt-c, Libunifex, and Json-cpp sucks.