### PR TITLE
feat: enhance build script to support single version documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(AIMRT_BUILD_DOCUMENT AND UNIX)
   message(STATUS "gen document ...")
   set(AIMRT_DOC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/document)
   execute_process(COMMAND ${AIMRT_DOC_DIR}/doxygen/build.sh ${AIMRT_DOC_DIR}/doxygen WORKING_DIRECTORY ${AIMRT_DOC_DIR}/doxygen)
-  execute_process(COMMAND ${AIMRT_DOC_DIR}/sphinx-cn/build.sh ${AIMRT_DOC_DIR}/sphinx-cn WORKING_DIRECTORY ${AIMRT_DOC_DIR}/sphinx-cn)
+  execute_process(COMMAND ${AIMRT_DOC_DIR}/sphinx-cn/build.sh ${AIMRT_DOC_DIR}/sphinx-cn --single-version WORKING_DIRECTORY ${AIMRT_DOC_DIR}/sphinx-cn)
 endif()
 
 # Include cmake module

--- a/document/sphinx-cn/build.sh
+++ b/document/sphinx-cn/build.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
 DIR=${1:-"./"}
+SINGLE_VERSION=false
+
+# Parse arguments
+for arg in "$@"
+do
+    if [ "$arg" == "--single-version" ]; then
+        SINGLE_VERSION=true
+    elif [ "$arg" != "--single-version" ] && [ -z "$DIR" ]; then
+        DIR=$arg
+    fi
+done
 
 mkdir -p $DIR/_build
 mkdir -p $DIR/_static
@@ -13,12 +24,13 @@ if command -v sphinx-build >/dev/null 2>&1; then
 
   cp $DIR/_static/html/index.html $DIR/_build/html/index.html
 
-  if [ -d ".git" ] || git rev-parse --git-dir > /dev/null 2>&1; then
-    echo "Using sphinx-multiversion to build multi-version documentation..."
-
-    sphinx-multiversion $DIR $DIR/_build/html
-  else
-    echo "Warning: Not a Git repository. Falling back to sphinx-build..."
+  if [ "$SINGLE_VERSION" = true ] || ! { [ -d ".git" ] || git rev-parse --git-dir > /dev/null 2>&1; }; then
+    # Build with sphinx-build for single version or non-git repos
+    [ "$SINGLE_VERSION" = true ] && echo "Building single version documentation..." || echo "Warning: Not a Git repository. Falling back to sphinx-build..."
     sphinx-build -b html $DIR $DIR/_build/html
+  else
+    # Build with sphinx-multiversion for git repos (multi-version)
+    echo "Using sphinx-multiversion to build multi-version documentation..."
+    sphinx-multiversion $DIR $DIR/_build/html
   fi
 fi


### PR DESCRIPTION
Added support for the --single-version argument in the build script. The script now checks if it's running in a Git repository and builds documentation accordingly, using sphinx-multiversion for multi-version or sphinx-build for single version or non-Git repositories.