### PR TITLE
fix: stabilize RPC timeout handling and correct time wheel scheduling bugs

### DIFF
--- a/document/sphinx-cn/release_notes/v1_7_0.md
+++ b/document/sphinx-cn/release_notes/v1_7_0.md
@@ -5,3 +5,8 @@
 **✨ 次要功能和优化**
 
 **🐛Bug 修复**
+
+- 修复timing wheel越界访问崩溃问题
+- 修复timing wheel executor由于计算溢出slot分配错误导致的超时配置不匹配问题
+- 修复ros2 service多模块共存时同名冲突无法注册的问题
+- 修复RpcClientTool可能的资源泄露导致崩溃的问题

--- a/document/sphinx-en/release_notes/v1_7_0.md
+++ b/document/sphinx-en/release_notes/v1_7_0.md
@@ -5,3 +5,8 @@
 **✨ Minor Features and Optimizations**
 
 **🐛 Bug Fixes**:
+
+- Fix out-of-bounds access crash in the timing-wheel
+- Correct time wheel slot placement error caused by integer division truncation
+- Use per-module key for ros2 rpc backend client/server registration
+- Protect RpcClientTool timeout callbacks from use-after-free via shared shutdown flag

--- a/src/plugins/ros2_plugin/ros2_rpc_backend.cc
+++ b/src/plugins/ros2_plugin/ros2_rpc_backend.cc
@@ -345,9 +345,11 @@ bool Ros2RpcBackend::RegisterServiceFunc(
       remapped_func_name = GetRemappedFuncName(info.func_name, find_option->func_name, find_option->remapping_rule);
     }
 
+    auto server_key = std::string(info.module_name) + ":" + std::string(info.func_name);
+
     // Messages with ros2 type prefix
     if (CheckRosFunc(info.func_name)) {
-      if (ros2_adapter_server_map_.find(info.func_name) != ros2_adapter_server_map_.end()) {
+      if (ros2_adapter_server_map_.find(server_key) != ros2_adapter_server_map_.end()) {
         AIMRT_WARN(
             "Service '{}' is registered repeatedly in ros2 rpc backend, module '{}', lib path '{}'",
             info.func_name, info.module_name, info.pkg_path);
@@ -365,17 +367,16 @@ bool Ros2RpcBackend::RegisterServiceFunc(
           std::dynamic_pointer_cast<rclcpp::ServiceBase>(ros2_adapter_server_ptr),
           nullptr);
 
-      ros2_adapter_server_map_.emplace(info.func_name,
-                                       ros2_adapter_server_ptr);
+      ros2_adapter_server_map_.emplace(server_key, ros2_adapter_server_ptr);
 
-      AIMRT_INFO("Service '{}' is registered to ros2 rpc backend, ros2 func name is '{}'",
-                 info.func_name, ros2_func_name);
+      AIMRT_INFO("Service '{}' is registered to ros2 rpc backend, module '{}', ros2 func name is '{}'",
+                 info.func_name, info.module_name, ros2_func_name);
 
       return true;
     }
 
     // Messages without ros2 type prefix
-    if (ros2_adapter_wrapper_server_map_.find(info.func_name) != ros2_adapter_wrapper_server_map_.end()) {
+    if (ros2_adapter_wrapper_server_map_.find(server_key) != ros2_adapter_wrapper_server_map_.end()) {
       AIMRT_WARN(
           "Service '{}' is registered repeatedly in ros2 rpc backend, module '{}', lib path '{}'",
           info.func_name, info.module_name, info.pkg_path);
@@ -393,11 +394,10 @@ bool Ros2RpcBackend::RegisterServiceFunc(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(ros2_adapter_wrapper_server_ptr),
         nullptr);
 
-    ros2_adapter_wrapper_server_map_.emplace(info.func_name,
-                                             ros2_adapter_wrapper_server_ptr);
+    ros2_adapter_wrapper_server_map_.emplace(server_key, ros2_adapter_wrapper_server_ptr);
 
-    AIMRT_INFO("Service '{}' is registered to ros2 rpc backend, ros2 func name is '{}'",
-               info.func_name, ros2_func_name);
+    AIMRT_INFO("Service '{}' is registered to ros2 rpc backend, module '{}', ros2 func name is '{}'",
+               info.func_name, info.module_name, ros2_func_name);
 
     return true;
   } catch (const std::exception& e) {
@@ -442,9 +442,11 @@ bool Ros2RpcBackend::RegisterClientFunc(
       remapped_func_name = GetRemappedFuncName(info.func_name, find_option->func_name, find_option->remapping_rule);
     }
 
+    auto client_key = std::string(info.module_name) + ":" + std::string(info.func_name);
+
     // Messages with ros2 type prefix
     if (CheckRosFunc(info.func_name)) {
-      if (ros2_adapter_client_map_.find(info.func_name) != ros2_adapter_client_map_.end()) {
+      if (ros2_adapter_client_map_.find(client_key) != ros2_adapter_client_map_.end()) {
         AIMRT_WARN(
             "Client '{}' is registered repeatedly in ros2 rpc backend, module '{}', lib path '{}'",
             info.func_name, info.module_name, info.pkg_path);
@@ -463,16 +465,16 @@ bool Ros2RpcBackend::RegisterClientFunc(
       ros2_node_ptr_->get_node_services_interface()->add_client(
           std::dynamic_pointer_cast<rclcpp::ClientBase>(ros2_adapter_client_ptr), nullptr);
 
-      ros2_adapter_client_map_.emplace(info.func_name, ros2_adapter_client_ptr);
+      ros2_adapter_client_map_.emplace(client_key, ros2_adapter_client_ptr);
 
-      AIMRT_INFO("Client '{}' is registered to ros2 rpc backend, ros2 func name is '{}'",
-                 info.func_name, ros2_func_name);
+      AIMRT_INFO("Client '{}' is registered to ros2 rpc backend, module '{}', ros2 func name is '{}'",
+                 info.func_name, info.module_name, ros2_func_name);
 
       return true;
     }
 
     // Messages without ros2 type prefix
-    if (ros2_adapter_wrapper_client_map_.find(info.func_name) != ros2_adapter_wrapper_client_map_.end()) {
+    if (ros2_adapter_wrapper_client_map_.find(client_key) != ros2_adapter_wrapper_client_map_.end()) {
       AIMRT_WARN(
           "Client '{}' is registered repeatedly in ros2 rpc backend, module '{}', lib path '{}'",
           info.func_name, info.module_name, info.pkg_path);
@@ -492,7 +494,7 @@ bool Ros2RpcBackend::RegisterClientFunc(
         std::dynamic_pointer_cast<rclcpp::ClientBase>(ros2_adapter_wrapper_client_ptr),
         nullptr);
 
-    ros2_adapter_wrapper_client_map_.emplace(info.func_name, ros2_adapter_wrapper_client_ptr);
+    ros2_adapter_wrapper_client_map_.emplace(client_key, ros2_adapter_wrapper_client_ptr);
 
     AIMRT_INFO("Client '{}' is registered to ros2 rpc backend, ros2 func name is '{}'",
                info.func_name, ros2_func_name);
@@ -530,9 +532,11 @@ void Ros2RpcBackend::Invoke(
       }
     }
 
+    auto client_key = std::string(info.module_name) + ":" + std::string(info.func_name);
+
     // Messages with ros2 type prefix
     if (CheckRosFunc(info.func_name)) {
-      auto finditr = ros2_adapter_client_map_.find(info.func_name);
+      auto finditr = ros2_adapter_client_map_.find(client_key);
       if (finditr == ros2_adapter_client_map_.end()) {
         AIMRT_WARN(
             "Client '{}' unregistered in ros2 rpc backend, module '{}', lib path '{}'",
@@ -555,7 +559,7 @@ void Ros2RpcBackend::Invoke(
     }
 
     // Messages without ros2 type prefix
-    auto finditr = ros2_adapter_wrapper_client_map_.find(info.func_name);
+    auto finditr = ros2_adapter_wrapper_client_map_.find(client_key);
     if (finditr == ros2_adapter_wrapper_client_map_.end()) {
       AIMRT_WARN(
           "Client '{}' unregistered in ros2 rpc backend, module '{}', lib path '{}'",

--- a/src/plugins/ros2_plugin/ros2_rpc_backend.h
+++ b/src/plugins/ros2_plugin/ros2_rpc_backend.h
@@ -155,11 +155,11 @@ class Ros2RpcBackend : public runtime::core::rpc::RpcBackendBase {
 
   std::shared_ptr<rclcpp::Node> ros2_node_ptr_;
 
-  std::unordered_map<std::string_view, std::shared_ptr<Ros2AdapterServer>> ros2_adapter_server_map_;
-  std::unordered_map<std::string_view, std::shared_ptr<Ros2AdapterClient>> ros2_adapter_client_map_;
+  std::unordered_map<std::string, std::shared_ptr<Ros2AdapterServer>> ros2_adapter_server_map_;
+  std::unordered_map<std::string, std::shared_ptr<Ros2AdapterClient>> ros2_adapter_client_map_;
 
-  std::unordered_map<std::string_view, std::shared_ptr<Ros2AdapterWrapperServer>> ros2_adapter_wrapper_server_map_;
-  std::unordered_map<std::string_view, std::shared_ptr<Ros2AdapterWrapperClient>> ros2_adapter_wrapper_client_map_;
+  std::unordered_map<std::string, std::shared_ptr<Ros2AdapterWrapperServer>> ros2_adapter_wrapper_server_map_;
+  std::unordered_map<std::string, std::shared_ptr<Ros2AdapterWrapperClient>> ros2_adapter_wrapper_client_map_;
 };
 
 }  // namespace aimrt::plugins::ros2_plugin

--- a/src/runtime/core/executor/time_wheel_executor.cc
+++ b/src/runtime/core/executor/time_wheel_executor.cc
@@ -182,14 +182,13 @@ void TimeWheelExecutor::ExecuteAt(
       return;
     }
 
-    // Current time point time_point_
-    uint64_t temp_current_tick_count = current_tick_count_;
-    uint64_t diff_tick_count = virtual_tp / dt_count_ - current_tick_count_;
+    uint64_t target_tick = virtual_tp / dt_count_;
+    uint64_t diff_tick_count = target_tick - current_tick_count_;
 
     const size_t len = options_.wheel_size.size();
     for (size_t ii = 0; ii < len; ++ii) {
       if (diff_tick_count < options_.wheel_size[ii]) {
-        auto pos = (diff_tick_count + temp_current_tick_count) % options_.wheel_size[ii];
+        auto pos = target_tick % options_.wheel_size[ii];
 
         // TODO(): Sorting tasks based on time and inserting them into it
         timing_wheel_vec_[ii].wheel[pos].emplace_back(
@@ -197,10 +196,10 @@ void TimeWheelExecutor::ExecuteAt(
         return;
       }
       diff_tick_count /= options_.wheel_size[ii];
-      temp_current_tick_count /= options_.wheel_size[ii];
+      target_tick /= options_.wheel_size[ii];
     }
 
-    timing_task_map_[diff_tick_count + temp_current_tick_count].emplace_back(
+    timing_task_map_[target_tick].emplace_back(
         TaskWithTimestamp{virtual_tp / dt_count_, std::move(task)});
   } catch (const std::exception& e) {
     AIMRT_ERROR("{}", e.what());

--- a/src/runtime/core/executor/time_wheel_executor.cc
+++ b/src/runtime/core/executor/time_wheel_executor.cc
@@ -101,7 +101,9 @@ void TimeWheelExecutor::Initialize(std::string_view name,
 
           while (!task_list.empty()) {
             auto itr = task_list.begin();
-            auto& cur_list = timing_wheel_vec_[ii].wheel[itr->tick_count % timing_wheel_vec_[ii].scale];
+            auto& cur_list =
+                timing_wheel_vec_[ii]
+                    .wheel[itr->tick_count % timing_wheel_vec_[ii].wheel.size()];
             cur_list.splice(cur_list.end(), task_list, itr);
           }
         }});

--- a/src/runtime/core/util/rpc_client_tool.h
+++ b/src/runtime/core/util/rpc_client_tool.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <memory>
 #include <optional>
 
 #include "aimrt_module_cpp_interface/executor/executor.h"
@@ -18,8 +20,8 @@ class RpcClientTool {
   using TimeoutHandle = std::function<void(MsgRecorder&&)>;
 
  public:
-  RpcClientTool() = default;
-  ~RpcClientTool() = default;
+  RpcClientTool() : shutdown_flag_(std::make_shared<std::atomic_bool>(false)) {}
+  ~RpcClientTool() { shutdown_flag_->store(true); }
 
   void RegisterTimeoutExecutor(aimrt::executor::ExecutorRef timeout_executor) {
     if (!timeout_executor.SupportTimerSchedule())
@@ -39,7 +41,13 @@ class RpcClientTool {
       return false;
 
     if (timeout_executor_) {
-      timeout_executor_.ExecuteAfter(timeout, [this, req_id]() {
+      // Capture shutdown_flag by shared_ptr so the timeout lambda
+      // remains safe even after RpcClientTool is destroyed.
+      auto flag = shutdown_flag_;
+      timeout_executor_.ExecuteAfter(timeout, [this, req_id, flag]() {
+        if (flag->load()) [[unlikely]]
+          return;
+
         auto msg_recorder_op = GetRecord(req_id);
         if (msg_recorder_op) [[unlikely]]
           timeout_handle_(std::move(*msg_recorder_op));
@@ -64,6 +72,8 @@ class RpcClientTool {
   }
 
  private:
+  std::shared_ptr<std::atomic_bool> shutdown_flag_;
+
   aimrt::executor::ExecutorRef timeout_executor_;
   TimeoutHandle timeout_handle_;
 


### PR DESCRIPTION
1. RPC timeout safety
Protect timeout callbacks in RpcClientTool from use-after-free
Introduce a shared shutdown flag to ensure callbacks do not execute after object destruction

2. Time wheel fixes
Fix slot misplacement issue caused by integer division truncation
Resolve potential crash scenarios in time wheel execution

3. RPC backend registration
Use per-module keys instead of global keys for ROS2 RPC client/server registration
Prevent conflicts when multiple modules are initialized