### PR TITLE
fix(ros2_util): bound-check fixed array in WriteMemberNested against …

### DIFF
--- a/src/common/ros2_util/json_convert.h
+++ b/src/common/ros2_util/json_convert.h
@@ -165,6 +165,8 @@ inline void WriteMemberNested(
   const auto *member_typeinfo =
       reinterpret_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(member.members_->data);
   if (member.is_array_) {
+    if (json[member.name_].size() > member.array_size_)
+      throw std::runtime_error("WriteMemberNested: json array size exceeds fixed array capacity"); // NOSONAR:cpp:S112 - consistent with existing error handling style in this file
     for (unsigned int i = 0; i < json[member.name_].size(); i++) {
       JsonToMessageImpl(
           json[member.name_][i],


### PR DESCRIPTION
## Summary

`src/common/ros2_util/json_convert.h` converts JSON payloads into ROS2
messages (`JsonToMessage`). For a fixed-length C-array member whose element
type is a nested message, `WriteMemberNested` iterates over the
**attacker-controlled** JSON array length without comparing it against the
member's declared `array_size_`:

```cpp
// json_convert.h WriteMemberNested, fixed-array branch (before this PR)
if (member.is_array_) {
  for (unsigned int i = 0; i < json[member.name_].size(); i++) {   // <-- no bound against member.array_size_
    JsonToMessageImpl(
        json[member.name_][i],
        member_typeinfo,
        buffer + member.offset_ + member_typeinfo->size_of_ * i);  // <-- OOB WRITE when json array is longer
  }
}
```

The scalar fixed-array path (`WriteMember`, lines 113-123) performs the
matching length check; `WriteMemberNested` does not — the asymmetry is the
root cause.

## Fix

Reject JSON arrays longer than the declared capacity before the copy loop,
mirroring `WriteMember`:

```cpp
if (member.is_array_) {
  if (json[member.name_].size() > member.array_size_)
    throw std::runtime_error("WriteMemberNested: json array size exceeds fixed array capacity");
  for (unsigned int i = 0; i < json[member.name_].size(); i++) {
    ...
  }
}
```

## Impact & reachability

- **CWE-787** heap out-of-bounds write; process crash or memory corruption.
  No RCE exploitation was performed in this research.
- Reachable over the network: `net_plugin` HTTP channel subscription
  (`Content-Type: application/json`) and HTTP RPC both deserialize JSON via
  `JsonToMessage` → `JsonToMessageImpl` → `WriteMemberNested`
  (`ros2_type_support.h:130-135`).
- Trigger: a JSON body whose fixed-array member provides **more elements than
  the message type declares** (e.g. 8 elements for a declared `fixed[4]`
  nested-array member).
- net_plugin channels/RPC have no authentication by default.

## Verification

- Trigger chain confirmed by reading the net_plugin HTTP channel/RPC backends,
  `ros2_type_support.h` (json `Deserialize`) and `json_convert.h` at
  `main @ 19ae48ed`.
- A/B: `WriteMember` (scalar fixed array) rejects mismatched lengths; this PR
  makes `WriteMemberNested` (nested fixed array) behave consistently.

## Affected versions

All versions up to and including v1.7.0 / `main @ 19ae48ed` (no fix commit
exists yet).