### PR TITLE
fix(mqtt): avoid delayed retries after partial writes

### DIFF
--- a/cmake/GetPahoMqttC.cmake
+++ b/cmake/GetPahoMqttC.cmake
@@ -12,13 +12,13 @@ set(paho_mqtt_c_DOWNLOAD_URL
 if(paho_mqtt_c_LOCAL_SOURCE)
   FetchContent_Declare(
     paho_mqtt_c
-    SOURCE_DIR ${paho_mqtt_c_LOCAL_SOURCE}
+    SOURCE_DIR ${paho_mqtt_c_LOCAL_SOURCE} PATCH_COMMAND ${CMAKE_COMMAND} -DPAHO_SOURCE_DIR=<SOURCE_DIR> -P ${CMAKE_CURRENT_LIST_DIR}/PatchPahoMqttC.cmake
     OVERRIDE_FIND_PACKAGE)
 else()
   FetchContent_Declare(
     paho_mqtt_c
     URL ${paho_mqtt_c_DOWNLOAD_URL}
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE PATCH_COMMAND ${CMAKE_COMMAND} -DPAHO_SOURCE_DIR=<SOURCE_DIR> -P ${CMAKE_CURRENT_LIST_DIR}/PatchPahoMqttC.cmake
     OVERRIDE_FIND_PACKAGE)
 endif()
 
@@ -76,6 +76,11 @@ if(NOT paho_mqtt_c_POPULATED)
 
   if(TARGET paho-mqtt3as-static)
     add_library(paho_mqtt_c::paho-mqtt3as-static ALIAS paho-mqtt3as-static)
+  endif()
+
+  if(AIMRT_BUILD_TESTS)
+    FetchContent_GetProperties(paho_mqtt_c)
+    add_test(NAME aimrt_paho_pending_write_patch COMMAND ${CMAKE_COMMAND} -DPAHO_SOURCE_DIR=${paho_mqtt_c_SOURCE_DIR} -P ${CMAKE_CURRENT_LIST_DIR}/VerifyPahoMqttCPatch.cmake)
   endif()
 
 endif()

--- a/cmake/PatchPahoMqttC.cmake
+++ b/cmake/PatchPahoMqttC.cmake
@@ -1,0 +1,32 @@
+if(NOT DEFINED PAHO_SOURCE_DIR)
+  message(FATAL_ERROR "PAHO_SOURCE_DIR is required")
+endif()
+
+set(socket_file "${PAHO_SOURCE_DIR}/src/Socket.c")
+if(NOT EXISTS "${socket_file}")
+  message(FATAL_ERROR "Paho Socket.c was not found: ${socket_file}")
+endif()
+
+file(READ "${socket_file}" socket_source)
+
+set(already_patched "\t\tint poll_timeout_ms = (mod_s.write_pending->count > 0) ? 0 : timeout_ms;")
+string(FIND "${socket_source}" "${already_patched}" already_patched_at)
+if(NOT already_patched_at EQUAL -1)
+  message(STATUS "Paho pending-write polling patch already applied")
+  return()
+endif()
+
+set(old_block
+    "\t\t/* Prevent performance issue by unlocking the socket_mutex while waiting for a ready socket. */\n\t\tPaho_thread_unlock_mutex(mutex);\n\t\t*rc = poll(mod_s.saved.fds_read, mod_s.saved.nfds, timeout_ms);"
+)
+set(new_block
+    "\t\tint poll_timeout_ms = (mod_s.write_pending->count > 0) ? 0 : timeout_ms;\n\n\t\t/* Prevent performance issue by unlocking the socket_mutex while waiting for a ready socket. */\n\t\tPaho_thread_unlock_mutex(mutex);\n\t\t/* A partial write must be retried without waiting for the read timeout. */\n\t\t*rc = poll(mod_s.saved.fds_read, mod_s.saved.nfds, poll_timeout_ms);"
+)
+string(FIND "${socket_source}" "${old_block}" old_block_at)
+if(old_block_at EQUAL -1)
+  message(FATAL_ERROR "Unsupported Paho Socket.c: expected poll timeout block was not found")
+endif()
+
+string(REPLACE "${old_block}" "${new_block}" socket_source "${socket_source}")
+file(WRITE "${socket_file}" "${socket_source}")
+message(STATUS "Applied Paho pending-write polling patch")

--- a/cmake/VerifyPahoMqttCPatch.cmake
+++ b/cmake/VerifyPahoMqttCPatch.cmake
@@ -1,0 +1,16 @@
+if(NOT DEFINED PAHO_SOURCE_DIR)
+  message(FATAL_ERROR "PAHO_SOURCE_DIR is required")
+endif()
+
+set(socket_file "${PAHO_SOURCE_DIR}/src/Socket.c")
+if(NOT EXISTS "${socket_file}")
+  message(FATAL_ERROR "Paho Socket.c was not found: ${socket_file}")
+endif()
+
+file(READ "${socket_file}" socket_source)
+string(FIND "${socket_source}" "int poll_timeout_ms = (mod_s.write_pending->count > 0) ? 0 : timeout_ms;" patched_at)
+if(patched_at EQUAL -1)
+  message(FATAL_ERROR "Paho pending-write polling patch is missing")
+endif()
+
+message(STATUS "Paho pending-write polling patch is present")

--- a/src/plugins/mqtt_plugin/CMakeLists.txt
+++ b/src/plugins/mqtt_plugin/CMakeLists.txt
@@ -50,5 +50,11 @@ if(AIMRT_BUILD_TESTS AND test_files)
   add_gtest_target(TEST_TARGET ${CUR_TARGET_NAME} TEST_SRC ${test_files})
 endif()
 
+if(AIMRT_BUILD_TESTS AND UNIX)
+  add_executable(aimrt_paho_pending_write_regression tests/paho_pending_write_regression_test.c)
+  target_link_libraries(aimrt_paho_pending_write_regression PRIVATE paho_mqtt_c::paho-mqtt3as-static)
+  add_test(NAME aimrt_paho_pending_write_regression COMMAND aimrt_paho_pending_write_regression)
+endif()
+
 # Set misc of target
 set_target_properties(${CUR_TARGET_NAME} PROPERTIES OUTPUT_NAME "aimrt_${CUR_DIR}")

--- a/src/plugins/mqtt_plugin/tests/paho_pending_write_regression_test.c
+++ b/src/plugins/mqtt_plugin/tests/paho_pending_write_regression_test.c
@@ -1,0 +1,96 @@
+#include "MQTTAsync.h"
+#include "Socket.h"
+#include "mutex_type.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+extern mutex_type socket_mutex;
+extern int Socket_addSocket(SOCKET socket);
+
+static double MonotonicSeconds(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    perror("clock_gettime");
+    exit(EXIT_FAILURE);
+  }
+  return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+}
+
+int main(void) {
+  int sockets[2] = {-1, -1};
+  const size_t payload_size = 4 * 1024 * 1024;
+  char* payload = NULL;
+  PacketBuffers empty_buffers = {0};
+  int rc = 0;
+  int ready_rc = 0;
+  double elapsed;
+
+  MQTTAsync_init_options init_options = MQTTAsync_init_options_initializer;
+  MQTTAsync_global_init(&init_options);
+  Socket_outInitialize();
+
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+    perror("socketpair");
+    return EXIT_FAILURE;
+  }
+
+  if (fcntl(sockets[0], F_SETFL, O_NONBLOCK) != 0) {
+    perror("fcntl");
+    return EXIT_FAILURE;
+  }
+
+  char fill[64 * 1024];
+  memset(fill, 'f', sizeof(fill));
+  while (write(sockets[0], fill, sizeof(fill)) > 0) {
+  }
+  if (errno != EAGAIN && errno != EWOULDBLOCK) {
+    perror("write");
+    return EXIT_FAILURE;
+  }
+
+  if (Socket_addSocket(sockets[0]) != 0) {
+    fprintf(stderr, "Socket_addSocket failed\n");
+    return EXIT_FAILURE;
+  }
+
+  payload = malloc(payload_size);
+  if (payload == NULL) {
+    perror("malloc");
+    return EXIT_FAILURE;
+  }
+  memset(payload, 'x', payload_size);
+
+  rc = Socket_putdatas(sockets[0], payload, payload_size, empty_buffers);
+  if (rc != TCPSOCKET_INTERRUPTED || Socket_noPendingWrites(sockets[0])) {
+    fprintf(stderr, "expected a pending short write, rc=%d pending=%d errno=%d\n", rc,
+            !Socket_noPendingWrites(sockets[0]), errno);
+    return EXIT_FAILURE;
+  }
+
+  elapsed = MonotonicSeconds();
+  (void)Socket_getReadySocket(0, 1000, socket_mutex, &ready_rc);
+  elapsed = MonotonicSeconds() - elapsed;
+
+  Socket_close(sockets[0]);
+  close(sockets[1]);
+  Socket_outTerminate();
+
+  if (ready_rc != 0) {
+    fprintf(stderr, "Socket_getReadySocket failed: rc=%d\n", ready_rc);
+    return EXIT_FAILURE;
+  }
+  if (elapsed >= 0.5) {
+    fprintf(stderr, "pending write polling took %.3f seconds\n", elapsed);
+    return EXIT_FAILURE;
+  }
+
+  printf("pending write polling returned in %.3f seconds\n", elapsed);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- Patch Paho MQTT C to skip the read poll timeout while writes are pending,preventing large RPC responses from exceeding AimRT's default timeout.
- Add a deterministic regression test for pending-write polling.