### PR TITLE
feat(logger): add compression support to rotate_file backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,10 @@ if(AIMRT_BUILD_RUNTIME)
   include(GetTBB)
   include(GetBackward)
 
+  # used by the rotate_file logger backend to compress rotated log files
+  include(GetZlib)
+  include(GetZstd)
+
   if(AIMRT_BUILD_PYTHON_RUNTIME)
     find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
     set(PYBIND11_PYTHON_VERSION ${Python3_VERSION})

--- a/cmake/GetMcap.cmake
+++ b/cmake/GetMcap.cmake
@@ -3,6 +3,9 @@
 
 include(FetchContent)
 
+# zstd is shared with the rotate_file logger backend
+include(GetZstd)
+
 message(STATUS "get mcap ...")
 
 set(MCAP_VERSION
@@ -25,49 +28,6 @@ else()
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     OVERRIDE_FIND_PACKAGE)
 endif()
-
-set(ZSTD_VERSION
-    "1.5.7"
-    CACHE STRING "zstd version to use")
-set(zstd_DOWNLOAD_URL
-    "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
-    CACHE STRING "")
-
-if(zstd_LOCAL_SOURCE)
-  FetchContent_Declare(
-    zstd
-    SOURCE_DIR ${zstd_LOCAL_SOURCE}
-    OVERRIDE_FIND_PACKAGE)
-else()
-  FetchContent_Declare(
-    zstd
-    URL ${zstd_DOWNLOAD_URL}
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    OVERRIDE_FIND_PACKAGE)
-endif()
-
-function(get_zstd)
-  FetchContent_GetProperties(zstd)
-  if(NOT zstd_POPULATED)
-    FetchContent_Populate(zstd)
-
-    set(ZSTD_BUILD_PROGRAMS
-        OFF
-        CACHE BOOL "" FORCE)
-    set(ZSTD_BUILD_SHARED
-        OFF
-        CACHE BOOL "" FORCE)
-    set(ZSTD_BUILD_STATIC
-        ON
-        CACHE BOOL "" FORCE)
-    set(ZSTD_BUILD_TESTS
-        OFF
-        CACHE BOOL "" FORCE)
-
-    add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR}/build/cmake EXCLUDE_FROM_ALL)
-    add_library(zstd::libzstd ALIAS libzstd_static)
-  endif()
-endfunction()
 
 set(LZ4_VERSION
     "1.10.0"

--- a/cmake/GetZlib.cmake
+++ b/cmake/GetZlib.cmake
@@ -1,0 +1,55 @@
+# Copyright (c) 2023, AgiBot Inc.
+# All rights reserved.
+
+include_guard(GLOBAL)
+
+include(FetchContent)
+
+message(STATUS "get zlib ...")
+
+set(ZLIB_VERSION
+    "1.3.1"
+    CACHE STRING "zlib version to use")
+set(zlib_DOWNLOAD_URL
+    "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz"
+    CACHE STRING "")
+
+if(zlib_LOCAL_SOURCE)
+  FetchContent_Declare(
+    zlib
+    SOURCE_DIR ${zlib_LOCAL_SOURCE}
+    OVERRIDE_FIND_PACKAGE)
+else()
+  FetchContent_Declare(
+    zlib
+    URL ${zlib_DOWNLOAD_URL}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    OVERRIDE_FIND_PACKAGE)
+endif()
+
+# Wrap it in a function to restrict the scope of the variables
+function(get_zlib)
+  FetchContent_GetProperties(zlib)
+  if(NOT zlib_POPULATED)
+    FetchContent_Populate(zlib)
+
+    set(ZLIB_BUILD_EXAMPLES OFF)
+
+    # zlib is only linked into aimrt targets, its own install rules are not needed
+    set(SKIP_INSTALL_ALL ON)
+
+    add_subdirectory(${zlib_SOURCE_DIR} ${zlib_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+    # wrap the static lib in an imported target, so that it is referenced by name in
+    # aimrt's export set instead of being required to be a part of it
+    if(NOT TARGET ZLIB::ZLIB)
+      add_library(ZLIB::ZLIB INTERFACE IMPORTED GLOBAL)
+      target_link_libraries(ZLIB::ZLIB INTERFACE zlibstatic)
+    endif()
+  endif()
+endfunction()
+
+get_zlib()
+
+# import targets:
+# ZLIB::ZLIB

--- a/cmake/GetZstd.cmake
+++ b/cmake/GetZstd.cmake
@@ -1,0 +1,62 @@
+# Copyright (c) 2024
+# All rights reserved.
+
+include_guard(GLOBAL)
+
+include(FetchContent)
+
+message(STATUS "get zstd ...")
+
+set(ZSTD_VERSION
+    "1.5.7"
+    CACHE STRING "zstd version to use")
+set(zstd_DOWNLOAD_URL
+    "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
+    CACHE STRING "")
+
+if(zstd_LOCAL_SOURCE)
+  FetchContent_Declare(
+    zstd
+    SOURCE_DIR ${zstd_LOCAL_SOURCE}
+    OVERRIDE_FIND_PACKAGE)
+else()
+  FetchContent_Declare(
+    zstd
+    URL ${zstd_DOWNLOAD_URL}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    OVERRIDE_FIND_PACKAGE)
+endif()
+
+function(get_zstd)
+  FetchContent_GetProperties(zstd)
+  if(NOT zstd_POPULATED)
+    FetchContent_Populate(zstd)
+
+    set(ZSTD_BUILD_PROGRAMS
+        OFF
+        CACHE BOOL "" FORCE)
+    set(ZSTD_BUILD_SHARED
+        OFF
+        CACHE BOOL "" FORCE)
+    set(ZSTD_BUILD_STATIC
+        ON
+        CACHE BOOL "" FORCE)
+    set(ZSTD_BUILD_TESTS
+        OFF
+        CACHE BOOL "" FORCE)
+
+    add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR}/build/cmake EXCLUDE_FROM_ALL)
+
+    # wrap the static lib in an imported target, so that it is referenced by name in
+    # aimrt's export set instead of being required to be a part of it
+    if(NOT TARGET zstd::libzstd)
+      add_library(zstd::libzstd INTERFACE IMPORTED GLOBAL)
+      target_link_libraries(zstd::libzstd INTERFACE libzstd_static)
+    endif()
+  endif()
+endfunction()
+
+get_zstd()
+
+# import targets:
+# zstd::libzstd

--- a/document/sphinx-cn/tutorials/cfg/log.md
+++ b/document/sphinx-cn/tutorials/cfg/log.md
@@ -125,6 +125,8 @@ aimrt:
 | sync_interval_ms      | unsigned int | 可选     | 30000                              | 定期主动落盘的时间间隔，单位：ms                |
 | sync_executor_name    | string       | 条件必选 | ""                                 | 定期落盘的执行器。 `enable_sync 为 true 时必选` |
 | suffix_with_timestamp | bool         | 可选     | true                               | 是否在日志文件名后面加上时间戳                  |
+| compression_mode      | string       | 可选     | "none"                             | 日志文件压缩方式，可选值：none/gzip/zstd        |
+| compression_level     | string       | 可选     | "default"                          | 日志文件压缩等级，可选值：fast/default/slow     |
 
 使用注意点如下：
 
@@ -139,6 +141,9 @@ aimrt:
 - `sync_interval_ms`配置定期落盘的时间间隔，单位：ms。 请在数据完整性和性能之间设置合适大小。
 - `sync_executor_name`配置定期落盘的执行器。用于定期落盘的执行器必须支持 timer scheduling。
 - `suffix_with_timestamp`配置是否在日志文件名后面加上时间戳， 该时间戳表示日志文件的旋转时间。
+- `compression_mode`配置日志文件的压缩方式。`none`表示不压缩；`gzip`表示使用 gzip 压缩，压缩后的文件添加`.gz`后缀；`zstd`表示使用 zstd 压缩，压缩后的文件添加`.zst`后缀。开启压缩后，一份日志文件写完并被重命名后，会立即压缩该文件并删除原文件。如果压缩失败，则保留原文件。
+- `compression_level`配置日志文件的压缩等级。`fast`表示快速压缩，速度最快，压缩率与 cpu 占用最低；`default`表示中等压缩，平衡压缩速度与 cpu 占用；`slow`表示慢速压缩，速度最慢，压缩率与 cpu 占用最高。仅在`compression_mode`不为`none`时生效。
+- 压缩在打印日志的 guard 线程上同步进行，压缩期间的日志会缓存在队列中。如果对日志的实时性要求较高，请使用`fast`等级或较小的`max_file_size_m`。
 
 以下是一个简单的示例：
 
@@ -161,5 +166,7 @@ aimrt:
           max_file_size_m: 4
           max_file_num: 10
           module_filter: "(.*)"
+          compression_mode: gzip
+          compression_level: default
           log_executor_name: test_log_executor.log
 ```

--- a/document/sphinx-en/tutorials/cfg/log.md
+++ b/document/sphinx-en/tutorials/cfg/log.md
@@ -126,6 +126,8 @@ The `rotate_file` log backend is an officially provided AimRT backend that write
 | sync_interval_ms      | unsigned int | Optional    | 30000                             | Periodic flush interval in ms                                |
 | sync_executor_name    | string       | Conditional | ""                                | Executor for periodic flush. Required if enable_sync is true |
 | suffix_with_timestamp | bool         | Optional    | true                              | Append timestamp suffix to log file name                     |
+| compression_mode      | string       | Optional    | "none"                            | Compression method of log files: none/gzip/zstd              |
+| compression_level     | string       | Optional    | "default"                         | Compression level of log files: fast/default/slow            |
 
 Usage notes:
 
@@ -141,6 +143,9 @@ Usage notes:
 - `sync_interval_ms` sets the flush interval in ms. Balance between data integrity and performance.
 - `sync_executor_name` specifies the executor for periodic flushing. The executor must support timer scheduling.
 - The `suffix_with_timestamp` configuration controls whether to append a timestamp to the log file name, which represents the log file rotation time.
+- `compression_mode` sets the compression method of log files. `none` means no compression; `gzip` compresses with gzip and appends a `.gz` suffix to the compressed file; `zstd` compresses with zstd and appends a `.zst` suffix. When compression is enabled, a log file is compressed right after it has been fully written and renamed, and then the original file is removed. If compression fails, the original file is kept.
+- `compression_level` sets the compression level of log files. `fast` means the fastest speed with the lowest compression ratio and cpu usage; `default` means a medium level balancing compression speed and cpu usage; `slow` means the slowest speed with the highest compression ratio and cpu usage. It only takes effect when `compression_mode` is not `none`.
+- Compression runs synchronously on the guard thread that prints logs, and logs are buffered in the queue while compressing. Use the `fast` level or a smaller `max_file_size_m` if logs are latency sensitive.
 
 Here is a simple example:
 
@@ -163,5 +168,7 @@ aimrt:
           max_file_size_m: 4
           max_file_num: 10
           module_filter: "(.*)"
+          compression_mode: gzip
+          compression_level: default
           log_executor_name: test_log_executor.log
 ```

--- a/src/examples/cpp/logger/README.md
+++ b/src/examples/cpp/logger/README.md
@@ -131,3 +131,40 @@
           sync_interval_ms: 5000                          # 定期落盘间隔，单位为 ms
           sync_executor_name: sync_timer_executor         # 指定定期落盘执行器名称，这里要和 executors 中列举的执行器列表匹配
 ```
+
+## logger rotate file with compression
+
+一个最基本的 cpp logger 示例，演示内容包括：
+
+- 如何使用 rotate_file 类型 Log 后端并了解其配置项；
+- 如何配置相关配置选项以开启日志压缩机制，节省日志占用的磁盘空间；
+
+核心代码：
+
+- [logger_bench_module.cc](./module/logger_bench_module/logger_bench_module.cc)
+- [pkg_main.cc](./pkg/logger_pkg/pkg_main.cc)
+
+配置文件：
+
+- [examples_cpp_logger_rotate_file_with_compression_cfg.yaml](./install/linux/bin/cfg/examples_cpp_logger_rotate_file_with_compression_cfg.yaml)
+
+运行方式（linux）：
+
+- 开启 `AIMRT_BUILD_EXAMPLES` 选项编译 AimRT；
+- 直接运行 build 目录下`start_examples_cpp_logger_rotate_file_with_compression.sh`脚本启动进程；
+- 等待进程打印出 bench 结果后自动结束，或键入`ctrl-c`停止进程；
+
+说明：
+
+- 此示例创建了一个 `LoggerBenchModule`，会在其 `Start` 的阶段批量打印日志，以产生足够多的日志触发文件滚动；
+- 此示例会在配置文件指定的目录中 "./log" 生成的日志文件 "examples_cpp_logger_rotate_file_with_compression.log" 文件，并将日志写入其中；
+- 每当一份日志文件写满并被滚动后，会被压缩为 ".gz" 文件，同时删除滚动后的原文件；
+- 可以看到在该配置文件中多了如下配置：
+
+```yaml
+      - type: rotate_file
+        options:
+          ...
+          compression_mode: gzip                          # 压缩方式，可选 none/gzip/zstd
+          compression_level: default                      # 压缩等级，可选 fast/default/slow
+```

--- a/src/examples/cpp/logger/install/linux/bin/cfg/examples_cpp_logger_rotate_file_with_compression_cfg.yaml
+++ b/src/examples/cpp/logger/install/linux/bin/cfg/examples_cpp_logger_rotate_file_with_compression_cfg.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2023, AgiBot Inc.
+# All rights reserved.
+
+aimrt:
+  log:
+    core_lvl: INFO # Trace/Debug/Info/Warn/Error/Fatal/Off
+    backends:
+      - type: console
+      - type: rotate_file
+        options:
+          path: ./log
+          filename: examples_cpp_logger_rotate_file_with_compression.log
+          max_file_size_m: 1
+          max_file_num: 10
+          compression_mode: gzip # none/gzip/zstd
+          compression_level: default # fast/default/slow
+  executor:
+    executors:
+      - name: work_executor
+        type: simple_thread
+  module:
+    pkgs:
+      - path: ./liblogger_pkg.so
+        enable_modules: [LoggerBenchModule]
+    modules:
+      - name: LoggerBenchModule
+        log_lvl: INFO
+
+# use the bench module to write enough logs to trigger rotation
+LoggerBenchModule:
+  log_data_size: [64, 256, 1024, 4096]
+  log_bench_num: 5000

--- a/src/examples/cpp/logger/install/linux/bin/start_examples_cpp_logger_rotate_file_with_compression.sh
+++ b/src/examples/cpp/logger/install/linux/bin/start_examples_cpp_logger_rotate_file_with_compression.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./aimrt_main --cfg_file_path=./cfg/examples_cpp_logger_rotate_file_with_compression_cfg.yaml

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -44,7 +44,9 @@ target_link_libraries(
          Backward::Backward
          aimrt::interface::aimrt_module_cpp_interface
          aimrt::interface::aimrt_core_plugin_interface
-         aimrt::common::util)
+         aimrt::common::util
+  PRIVATE ZLIB::ZLIB
+          zstd::libzstd)
 
 # Set compile options of target
 if(AIMRT_ENABLE_DLOPEN_DEEPBIND)

--- a/src/runtime/core/logger/rotate_file_logger_backend.cc
+++ b/src/runtime/core/logger/rotate_file_logger_backend.cc
@@ -2,10 +2,15 @@
 // All rights reserved.
 
 #include "core/logger/rotate_file_logger_backend.h"
+#include <zlib.h>
+#include <zstd.h>
+#include <charconv>
 #include <filesystem>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <regex>
+#include <vector>
 #include "util/exception.h"
 #include "util/string_util.h"
 
@@ -26,6 +31,8 @@ struct convert<aimrt::runtime::core::logger::RotateFileLoggerBackend::Options> {
     node["sync_interval_ms"] = rhs.sync_interval_ms;
     node["sync_executor_name"] = rhs.sync_executor_name;
     node["suffix_with_timestamp"] = rhs.suffix_with_timestamp;
+    node["compression_mode"] = rhs.compression_mode;
+    node["compression_level"] = rhs.compression_level;
 
     return node;
   }
@@ -51,6 +58,10 @@ struct convert<aimrt::runtime::core::logger::RotateFileLoggerBackend::Options> {
       rhs.enable_sync = node["enable_sync"].as<bool>();
     if (node["suffix_with_timestamp"])
       rhs.suffix_with_timestamp = node["suffix_with_timestamp"].as<bool>();
+    if (node["compression_mode"])
+      rhs.compression_mode = node["compression_mode"].as<std::string>();
+    if (node["compression_level"])
+      rhs.compression_level = node["compression_level"].as<std::string>();
 
     return true;
   }
@@ -58,6 +69,76 @@ struct convert<aimrt::runtime::core::logger::RotateFileLoggerBackend::Options> {
 }  // namespace YAML
 
 namespace aimrt::runtime::core::logger {
+
+namespace {
+
+using CompressionMode = RotateFileLoggerBackend::CompressionMode;
+using CompressionLevel = RotateFileLoggerBackend::CompressionLevel;
+
+constexpr std::string_view kGzipFileExtension = ".gz";
+constexpr std::string_view kZstdFileExtension = ".zst";
+
+constexpr size_t kCompressBufSize = 128 * 1024;
+
+std::string_view GetCompressedFileExtension(CompressionMode mode) {
+  return (mode == CompressionMode::kGzip) ? kGzipFileExtension : kZstdFileExtension;
+}
+
+// zlib deflate level, valid range [1, 9], 6 is the zlib default level.
+// note that gzopen only accepts a digit in its mode string, so
+// Z_DEFAULT_COMPRESSION can not be used here
+int GetGzipLevel(CompressionLevel level) {
+  switch (level) {
+    case CompressionLevel::kFast:
+      return 1;
+    case CompressionLevel::kSlow:
+      return 9;
+    default:
+      return 6;
+  }
+}
+
+// zstd compression level, valid range [1, 22]
+int GetZstdLevel(CompressionLevel level) {
+  switch (level) {
+    case CompressionLevel::kFast:
+      return 1;
+    case CompressionLevel::kSlow:
+      return 19;
+    default:
+      return ZSTD_CLEVEL_DEFAULT;
+  }
+}
+
+// rotated log file is named as '<base>_<index>[_<timestamp>][<compressed file extension>]',
+// returns the index, or nullopt if the file does not belong to this backend
+std::optional<uint32_t> ParseRotatedFileIndex(
+    std::string_view file_name, std::string_view base_file_name) {
+  if (file_name.size() <= base_file_name.size() + 1) return std::nullopt;
+  if (!file_name.starts_with(base_file_name)) return std::nullopt;
+  if (file_name[base_file_name.size()] != '_') return std::nullopt;
+
+  // compressed files keep the rotated name and only append an extension
+  for (auto extension : {kGzipFileExtension, kZstdFileExtension}) {
+    if (file_name.ends_with(extension)) {
+      file_name.remove_suffix(extension.size());
+      break;
+    }
+  }
+
+  std::string_view suffix = file_name.substr(base_file_name.size() + 1);
+  if (auto sep = suffix.find('_'); sep != std::string_view::npos) suffix = suffix.substr(0, sep);
+
+  if (!aimrt::common::util::IsDigitStr(suffix)) return std::nullopt;
+
+  uint32_t idx = 0;
+  auto result = std::from_chars(suffix.data(), suffix.data() + suffix.size(), idx);
+  if (result.ec != std::errc()) return std::nullopt;
+
+  return idx;
+}
+
+}  // namespace
 
 RotateFileLoggerBackend::~RotateFileLoggerBackend() {
   if (options_.enable_sync) {
@@ -91,6 +172,27 @@ void RotateFileLoggerBackend::Initialize(YAML::Node options_node) {
     pattern_ = options_.pattern;
   }
   formatter_.SetPattern(pattern_);
+
+  static const std::map<std::string, CompressionMode, std::less<>> kCompressionModeMap{
+      {"none", CompressionMode::kNone},
+      {"gzip", CompressionMode::kGzip},
+      {"zstd", CompressionMode::kZstd}};
+  static const std::map<std::string, CompressionLevel, std::less<>> kCompressionLevelMap{
+      {"fast", CompressionLevel::kFast},
+      {"default", CompressionLevel::kDefault},
+      {"slow", CompressionLevel::kSlow}};
+
+  auto compression_mode_itr = kCompressionModeMap.find(options_.compression_mode);
+  AIMRT_ASSERT(compression_mode_itr != kCompressionModeMap.end(),
+               "Invalid compression mode: {}, optional values are none/gzip/zstd.",
+               options_.compression_mode);
+  compression_mode_ = compression_mode_itr->second;
+
+  auto compression_level_itr = kCompressionLevelMap.find(options_.compression_level);
+  AIMRT_ASSERT(compression_level_itr != kCompressionLevelMap.end(),
+               "Invalid compression level: {}, optional values are fast/default/slow.",
+               options_.compression_level);
+  compression_level_ = compression_level_itr->second;
 
   // if enable_sync, set sync timer
   if (options_.enable_sync) {
@@ -225,7 +327,132 @@ void RotateFileLoggerBackend::Rename() {
     suffix.append(buf, 16);
   }
 
-  std::filesystem::rename(base_file_name_, base_file_name_ + "_" + suffix);
+  std::string rotated_file_name = base_file_name_ + "_" + suffix;
+  std::filesystem::rename(base_file_name_, rotated_file_name);
+
+  if (compression_mode_ != CompressionMode::kNone) {
+    CompressFile(rotated_file_name);
+  }
+}
+
+void RotateFileLoggerBackend::CompressFile(const std::string& src_file_path) {
+  std::string dst_file_path =
+      src_file_path + std::string(GetCompressedFileExtension(compression_mode_));
+
+  bool ret = false;
+  try {
+    ret = (compression_mode_ == CompressionMode::kGzip)
+              ? CompressGzip(src_file_path, dst_file_path)
+              : CompressZstd(src_file_path, dst_file_path);
+  } catch (const std::exception& e) {
+    (void)fprintf(stderr, "Compress log file %s get exception: %s\n",
+                  src_file_path.c_str(), e.what());
+  }
+
+  std::error_code ec;
+  if (!ret) {
+    // keep the original log file and drop the incomplete compressed one
+    (void)fprintf(stderr, "compress log file %s failed.\n", src_file_path.c_str());
+    std::filesystem::remove(dst_file_path, ec);
+    return;
+  }
+
+  if (!std::filesystem::remove(src_file_path, ec)) {
+    (void)fprintf(stderr, "remove log file %s failed: %s\n",
+                  src_file_path.c_str(), ec.message().c_str());
+  }
+}
+
+bool RotateFileLoggerBackend::CompressGzip(
+    const std::string& src_file_path, const std::string& dst_file_path) {
+  FILE* src_file = fopen(src_file_path.c_str(), "rb");
+  if (src_file == nullptr) return false;
+
+  std::string mode = "wb" + std::to_string(GetGzipLevel(compression_level_));
+  gzFile dst_file = gzopen(dst_file_path.c_str(), mode.c_str());
+  if (dst_file == nullptr) {
+    (void)fclose(src_file);
+    return false;
+  }
+
+  bool ret = true;
+  std::vector<char> buf(kCompressBufSize);
+
+  while (true) {
+    size_t read_size = fread(buf.data(), 1, buf.size(), src_file);
+    if (read_size == 0) {
+      ret = (ferror(src_file) == 0);
+      break;
+    }
+
+    if (gzwrite(dst_file, buf.data(), static_cast<unsigned int>(read_size)) !=
+        static_cast<int>(read_size)) {
+      ret = false;
+      break;
+    }
+  }
+
+  (void)fclose(src_file);
+  if (gzclose(dst_file) != Z_OK) ret = false;
+
+  return ret;
+}
+
+bool RotateFileLoggerBackend::CompressZstd(
+    const std::string& src_file_path, const std::string& dst_file_path) {
+  ZSTD_CCtx* cctx = ZSTD_createCCtx();
+  if (cctx == nullptr) return false;
+
+  (void)ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, GetZstdLevel(compression_level_));
+
+  FILE* src_file = fopen(src_file_path.c_str(), "rb");
+  FILE* dst_file = (src_file == nullptr) ? nullptr : fopen(dst_file_path.c_str(), "wb");
+  if (dst_file == nullptr) {
+    if (src_file != nullptr) (void)fclose(src_file);
+    (void)ZSTD_freeCCtx(cctx);
+    return false;
+  }
+
+  bool ret = true;
+  std::vector<char> in_buf(ZSTD_CStreamInSize());
+  std::vector<char> out_buf(ZSTD_CStreamOutSize());
+
+  while (ret) {
+    size_t read_size = fread(in_buf.data(), 1, in_buf.size(), src_file);
+    if (read_size < in_buf.size() && ferror(src_file) != 0) {
+      ret = false;
+      break;
+    }
+
+    bool last_chunk = (feof(src_file) != 0);
+    ZSTD_inBuffer input{in_buf.data(), read_size, 0};
+
+    // one input chunk may need several output chunks to be flushed out
+    while (true) {
+      ZSTD_outBuffer output{out_buf.data(), out_buf.size(), 0};
+      size_t remaining = ZSTD_compressStream2(cctx, &output, &input,
+                                              last_chunk ? ZSTD_e_end : ZSTD_e_continue);
+      if (ZSTD_isError(remaining) != 0) {
+        ret = false;
+        break;
+      }
+
+      if (fwrite(out_buf.data(), 1, output.pos, dst_file) != output.pos) {
+        ret = false;
+        break;
+      }
+
+      if (last_chunk ? (remaining == 0) : (input.pos == input.size)) break;
+    }
+
+    if (last_chunk) break;
+  }
+
+  (void)fclose(src_file);
+  if (fclose(dst_file) != 0) ret = false;
+  (void)ZSTD_freeCCtx(cctx);
+
+  return ret;
 }
 
 void RotateFileLoggerBackend::CleanLogFile() {
@@ -239,16 +466,10 @@ void RotateFileLoggerBackend::CleanLogFile() {
   for (std::filesystem::directory_iterator itr(log_dir); itr != end_itr; ++itr) {
     const std::string& cur_log_file_name = itr->path().string();
 
-    if (cur_log_file_name.size() <= base_file_name_.size() + 1) continue;
-    if (cur_log_file_name.substr(0, base_file_name_.size() + 1) != (base_file_name_ + "_")) continue;
+    auto cur_idx = ParseRotatedFileIndex(cur_log_file_name, base_file_name_);
+    if (!cur_idx) continue;
 
-    std::string cur_log_file_name_suffix = cur_log_file_name.substr(base_file_name_.size() + 1);
-    cur_log_file_name_suffix = cur_log_file_name_suffix.substr(0, cur_log_file_name_suffix.find('_'));
-
-    if (!aimrt::common::util::IsDigitStr(cur_log_file_name_suffix)) continue;
-
-    uint32_t cur_idx = atoi(cur_log_file_name_suffix.c_str());
-    log_files.emplace(cur_idx, cur_log_file_name);
+    log_files.emplace(*cur_idx, cur_log_file_name);
   }
 
   if (log_files.size() <= options_.max_file_num) return;
@@ -270,17 +491,11 @@ uint32_t RotateFileLoggerBackend::GetNextIndex() {
   for (std::filesystem::directory_iterator itr(log_dir); itr != end_itr;
        ++itr) {
     const std::string& cur_log_file_name = itr->path().string();
-    if (cur_log_file_name.size() <= base_file_name_.size() + 1) continue;
-    if (cur_log_file_name.substr(0, base_file_name_.size() + 1) !=
-        (base_file_name_ + "_"))
-      continue;
 
-    std::string cur_log_file_name_suffix = cur_log_file_name.substr(base_file_name_.size() + 1);
-    cur_log_file_name_suffix = cur_log_file_name_suffix.substr(0, cur_log_file_name_suffix.find('_'));
+    auto cur_idx = ParseRotatedFileIndex(cur_log_file_name, base_file_name_);
+    if (!cur_idx) continue;
 
-    if (!aimrt::common::util::IsDigitStr(cur_log_file_name_suffix)) continue;
-    uint32_t cur_idx = atoi(cur_log_file_name_suffix.c_str());
-    if (cur_idx >= idx) idx = cur_idx + 1;
+    if (*cur_idx >= idx) idx = *cur_idx + 1;
   }
 
   return idx;

--- a/src/runtime/core/logger/rotate_file_logger_backend.h
+++ b/src/runtime/core/logger/rotate_file_logger_backend.h
@@ -17,6 +17,18 @@ namespace aimrt::runtime::core::logger {
 
 class RotateFileLoggerBackend : public LoggerBackendBase {
  public:
+  enum class CompressionMode : uint8_t {
+    kNone,
+    kGzip,
+    kZstd,
+  };
+
+  enum class CompressionLevel : uint8_t {
+    kFast,
+    kDefault,
+    kSlow,
+  };
+
   struct Options {
     std::string path = "./log";
     std::string filename = "aimrt.log";
@@ -28,6 +40,8 @@ class RotateFileLoggerBackend : public LoggerBackendBase {
     uint32_t sync_interval_ms = 30000;  // default: 30 s
     std::string sync_executor_name = "";
     bool suffix_with_timestamp = true;
+    std::string compression_mode = "none";      // none/gzip/zstd
+    std::string compression_level = "default";  // fast/default/slow
   };
 
  public:
@@ -62,11 +76,19 @@ class RotateFileLoggerBackend : public LoggerBackendBase {
   bool CheckLog(const LogDataWrapper& log_data_wrapper);
   void Rename();
 
+  // compress the rotated log file, then remove the original one
+  void CompressFile(const std::string& src_file_path);
+  bool CompressGzip(const std::string& src_file_path, const std::string& dst_file_path);
+  bool CompressZstd(const std::string& src_file_path, const std::string& dst_file_path);
+
  private:
   Options options_;
   std::function<aimrt::executor::ExecutorRef(std::string_view)> get_executor_func_;
   executor::ExecutorRef log_executor_;
   executor::ExecutorRef timer_executor_;
+
+  CompressionMode compression_mode_ = CompressionMode::kNone;
+  CompressionLevel compression_level_ = CompressionLevel::kDefault;
 
   std::string base_file_name_;
   std::ofstream ofs_;

--- a/src/test/cases/cpp/logger/examples_cpp_logger_rotate_file_with_compression.yaml
+++ b/src/test/cases/cpp/logger/examples_cpp_logger_rotate_file_with_compression.yaml
@@ -1,0 +1,22 @@
+name: "cpp_logger_rotate_file_with_compression"
+description: "Test for examples_cpp_logger_rotate_file_with_compression"
+
+config:
+  execution_count: 1
+  time_sec: 60
+  cwd: "${CWD}"
+
+
+input:
+  scripts:
+    - path: "./start_examples_cpp_logger_rotate_file_with_compression.sh"
+      args: []
+      depends_on: []
+      delay_sec: 0
+      cwd: ""
+      time_sec: 60
+      monitor:
+        cpu: true
+        memory: true
+        disk: true
+      shutdown_patterns: ["report:"]

--- a/src/test/cases/cpp/logger/test_cpp_logger_file.py
+++ b/src/test/cases/cpp/logger/test_cpp_logger_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from test_helpers.fixtures.aimrt_test import AimRTTestRunner
 from test_helpers.core.callback_manager import CallbackTrigger, CallbackResult
 from typing import Dict, Any
+import gzip
 import os
 import time
 
@@ -14,6 +15,9 @@ CASES = [
     'examples_cpp_logger_rotate_file.yaml',
     'examples_cpp_logger_rotate_file_with_sync.yaml',
 ]
+
+COMPRESSION_CASE = 'examples_cpp_logger_rotate_file_with_compression.yaml'
+COMPRESSION_LOG_NAME = 'examples_cpp_logger_rotate_file_with_compression.log'
 
 
 def file_check(ctx: Dict[str, Any]) -> CallbackResult:
@@ -57,6 +61,69 @@ def test_logger_file_examples(yaml_name: str, aimrt_test_runner: AimRTTestRunner
         pytest.fail('Failed to setup test environment from YAML configuration')
 
     aimrt_test_runner.register_function_callback('test_cpp_logger_file', CallbackTrigger.PROCESS_END, file_check)
+
+    success = aimrt_test_runner.run_test()
+    if not success:
+        pytest.fail('Test execution failed')
+
+
+def compression_check(ctx: Dict[str, Any]) -> CallbackResult:
+    p = ctx.get('process_info')
+
+    if not p:
+        return CallbackResult(False, 'missing process_info')
+
+    cwd_env = (os.environ.get('CWD') or '').strip()
+    base = Path(cwd_env or os.getcwd()).resolve()
+
+    log_dir = Path(base) / 'log'
+    rotated_files = list(log_dir.glob(COMPRESSION_LOG_NAME + '_*'))
+    compressed_files = [f for f in rotated_files if f.suffix == '.gz']
+    uncompressed_files = [f for f in rotated_files if f.suffix != '.gz']
+
+    data = {
+        'script_path': getattr(p, 'script_path', ''),
+        'compressed_files': [f.name for f in compressed_files],
+        'uncompressed_files': [f.name for f in uncompressed_files],
+    }
+
+    if not compressed_files:
+        return CallbackResult(False, 'no compressed log file found', data=data)
+
+    # the rotated log file should be removed once it is compressed
+    if uncompressed_files:
+        return CallbackResult(False, 'rotated log file is not removed after compression', data=data)
+
+    ok = True
+    msg = 'compressed log file verification passed'
+    for compressed_file in compressed_files:
+        try:
+            with gzip.open(compressed_file, 'rb') as f:
+                while f.read(1024 * 1024):
+                    pass
+        except OSError as e:
+            ok = False
+            msg = f'broken compressed log file {compressed_file.name}: {e}'
+            break
+
+    for f in rotated_files:
+        f.unlink()
+    (log_dir / COMPRESSION_LOG_NAME).unlink(missing_ok=True)
+
+    return CallbackResult(ok, msg, data=data)
+
+
+def test_logger_file_compression_example(aimrt_test_runner: AimRTTestRunner):
+    yaml_path = (Path(__file__).parent / COMPRESSION_CASE).resolve()
+    if not yaml_path.exists():
+        pytest.skip(f'YAML not found: {yaml_path}')
+    if not aimrt_test_runner.setup_from_yaml(str(yaml_path)):
+        pytest.fail('Failed to setup test environment from YAML configuration')
+
+    aimrt_test_runner.register_function_callback(
+        'test_cpp_logger_file_compression',
+        CallbackTrigger.PROCESS_END,
+        compression_check)
 
     success = aimrt_test_runner.run_test()
     if not success:


### PR DESCRIPTION
## Background

Add log compression support to the `rotate_file` log backend, reducing disk usage for rotated log files.

## Changes

Two new backend config options:

| Option | Values | Default | Description |
| --- | --- | --- | --- |
| `compression_mode` | `none` / `gzip` / `zstd` | `none` | Compression algorithm |
| `compression_level` | `fast` / `default` / `slow` | `default` | Compression level |

- After a log file reaches the size limit and is rotated, it is compressed immediately in-place. On success the original rotated file is deleted; the compressed file keeps the rotated name with a `.gz` / `.zst` suffix appended.
- On compression failure the incomplete output is deleted and the original file is kept; a message is printed to stderr and logging continues unaffected.
- Compression runs synchronously on the guard thread that writes logs (log data queues in the executor during compression) — no extra thread is introduced.
- Level mapping: gzip → zlib deflate level 1 / 6 / 9; zstd → level 1 / 3 (`ZSTD_CLEVEL_DEFAULT`) / 19.
- An invalid `compression_mode` or `compression_level` value causes `Initialize` to throw immediately, with the list of accepted values in the error message.

Build:

- Added `cmake/GetZlib.cmake` and `cmake/GetZstd.cmake`; both libraries are linked `PRIVATE` into `aimrt_runtime_core` via INTERFACE IMPORTED targets (`ZLIB::ZLIB` / `zstd::libzstd`) so they do not appear in the installed `aimrt-config` export set.
- The inline zstd declaration in `GetMcap.cmake` is extracted into `GetZstd.cmake` so the record-playback plugin and the log backend share a single copy.

Also fixes a pre-existing bug: the rotated-file index parser in `GetNextIndex()` and `CleanLogFile()` did not tolerate file-name suffixes. With compression enabled and `suffix_with_timestamp: false`, compressed files were invisible to index allocation and file-count cleanup (index reuse + `max_file_num` not enforced). These are unified into a single `ParseRotatedFileIndex()` helper.

## Verification

Tested in a `ros:humble-ros-base-jammy` container on a dev machine using the `LoggerBenchModule` example (~30 MB of logs, 29 rotations per run). 11 test cases, all passed:

| Case | Ratio | CPU time | gzip XFL |
| --- | --- | --- | --- |
| none / default | 1.0000 | 0.15 s | — |
| gzip / fast | 0.0098 | 0.18 s | 4 (level 1) |
| gzip / default | 0.0051 | 0.22 s | 0 (level 6) |
| gzip / slow | 0.0045 | 0.28 s | 2 (level 9) |
| zstd / fast | 0.0026 | 0.17 s | — |
| zstd / default | 0.0031 | 0.20 s | — |
| zstd / slow | 0.0023 | 1.57 s | — |

- All compressed outputs were decompressed and verified (total 30.4 MB restored, no corruption).
- gzip XFL byte confirms the actual zlib level delivered for each setting.
- `suffix_with_timestamp: false` + gzip: rotation indices and compressed outputs are normal.
- `max_file_num: 3` + gzip: compressed files are counted toward the limit correctly.
- Invalid `compression_mode: lz4` / `compression_level: fastest`: process exits immediately (exit 255) with an error listing valid values.
- Ratios above are for high-repetition bench logs (optimistic). On a real 371 KB build log: gzip 9.9% / 8.0% / 7.8%, zstd 9.1% / 8.8% / 7.0%.

Also adds an example and test case: `examples_cpp_logger_rotate_file_with_compression` (config yaml, start script, test-case yaml) and a new test in `test_cpp_logger_file.py` that checks compressed output exists, original is deleted, and output is decompressible.
